### PR TITLE
Make Maintainers Happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+all: install
+
+install:
+	mkdir -p $(DESTDIR)/usr/share/icons
+	cp --no-preserve=mode,ownership -r \
+		ePapirus Papirus Papirus-Light Papirus-Dark /usr/share/icons
+	-gtk-update-icon-cache -q $(DESTDIR)/usr/share/icons/ePapirus
+	-gtk-update-icon-cache -q $(DESTDIR)/usr/share/icons/Papirus
+	-gtk-update-icon-cache -q $(DESTDIR)/usr/share/icons/Papirus-Dark
+	-gtk-update-icon-cache -q $(DESTDIR)/usr/share/icons/Papirus-Light
+
+uninstall:
+	-rm -rf $(DESTDIR)/usr/share/icons/ePapirus
+	-rm -rf $(DESTDIR)/usr/share/icons/Papirus
+	-rm -rf $(DESTDIR)/usr/share/icons/Papirus-Dark
+	-rm -rf $(DESTDIR)/usr/share/icons/Papirus-Light
+
+_get_version:
+	$(eval DATE := $(shell git log -1 --format=%cd --date=format:%Y.%m.%d))
+	$(eval COUNT := $(shell git rev-list --all --count))
+	$(eval VERSION := $(DATE)-r$(COUNT))
+
+push:
+	git push origin
+
+release: _get_version push
+	git tag -f $(VERSION)
+	git push origin --tags
+
+undo_release: _get_version
+	-git tag -d $(VERSION)
+	-git push --delete origin $(VERSION)
+
+
+.PHONY: all install uninstall _get_version push release undo_release

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ wget -qO- https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-
 wget -qO- https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme/master/remove-papirus.sh | sh
 ```
 
+# Unofficial packages
+Packages in this section are not part of the official repositories. If you have a trouble or a question please contact with package maintainer.
+
+| **Distro** | **Maintainer** | **Package** |
+|:-----------|:---------------|:------------|
+| Arch Linux | Edgard Castro  | [papirus-icon-theme-git](https://aur.archlinux.org/packages/papirus-icon-theme-git/) (AUR) |
+
+**NOTE:** If you maintainer and want be in the list please create an issue or send a pull request.
+
 # Hardcoded tray icons
 
 Papirus icon theme now supports [Hardcode-Tray](https://github.com/bil-elmoussaoui/Hardcode-Tray) script


### PR DESCRIPTION
Предлагаю повернутся лицом к ментейнерам и сделать следующее:

- добавить Makefile и задачи `make install` и `make uninstall` и поддерживать их
- добавить в README список неофициальных пакетов, чтобы похвалить текущих и способствовать появлению новых ментейнеров
- создавать релизы на GitHub, скажем, каждые одну-две недели обычные и раз в месяц со списком изменений  

Для последнего есть задача в Makefile `make release`, осталось только согласовать версионирование, я выбрал формат `YYYY.MM.DD-r#COMMIT` (пример `2017.01.10-r697`) как более подходящий для CI проекта.