### PR TITLE
Added an icon for the MAME emulator; see http://mamedev.org/

### DIFF
--- a/Papirus/16x16/apps/mame.svg
+++ b/Papirus/16x16/apps/mame.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 16 16" width="16" version="1.1">
+ <path style="fill:#428bca;fill-rule:evenodd;stroke-width:0.02830378;;" d="M 11,2 0,13 H 5 L 9,9 v 4 L 13.5,8.5 V 13 L 16,10.5 v -8 l -5,5 z"/>
+</svg>

--- a/Papirus/22x22/apps/mame.svg
+++ b/Papirus/22x22/apps/mame.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="22" viewBox="0 0 22 22" width="22" version="1.1">
+ <path style="fill-opacity:0.2;fill-rule:evenodd;stroke-width:0.03537972;;" d="M 14.5,4 0.9999998,17.5 h 6 L 12.5,12 v 5.5 L 18,12 v 5.5 l 3,-3 V 4.5 L 14.5,11 Z"/>
+ <path style="fill:#428bca;fill-rule:evenodd;stroke-width:0.03537972;;" d="M 14.5,3.5 0.9999998,17 h 6 L 12.5,11.5 V 17 L 18,11.5 V 17 l 3,-3 V 4 l -6.5,6.5 z"/>
+ <path style="opacity:0.2;fill:#ffffff;fill-rule:evenodd;stroke-width:0.05;;" d="M 14.5,3.5 0.9999998,17 h 0.5 L 14.5,4 Z M 21,4 14.5,10.5 V 11 L 21,4.5 Z"/>
+</svg>

--- a/Papirus/24x24/apps/mame.svg
+++ b/Papirus/24x24/apps/mame.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" viewBox="0 0 24 24">
+ <path style="fill-opacity:0.2;fill-rule:evenodd;stroke-width:0.03537972;;" d="M 15.5,5 2,18.5 H 8 L 13.5,13 v 5.5 L 19,13 v 5.5 l 3,-3 V 5.5 L 15.5,12 Z"/>
+ <path style="fill:#428bca;fill-rule:evenodd;stroke-width:0.03537972;;" d="M 15.5,4.5 2,18 h 6 l 5.5,-5.5 V 18 L 19,12.5 V 18 l 3,-3 V 5 l -6.5,6.5 z"/>
+ <path style="opacity:0.2;fill:#ffffff;fill-rule:evenodd;stroke-width:0.05;;" d="M 15.5,4.5 2,18 H 2.5 L 15.5,5 Z M 22,5 15.5,11.5 V 12 L 22,5.5 Z"/>
+</svg>

--- a/Papirus/32x32/apps/mame.svg
+++ b/Papirus/32x32/apps/mame.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="32" viewBox="0 0 32 32" width="32" version="1.1">
+ <path style="fill-opacity:0.2;fill-rule:evenodd;stroke-width:0.0495316;;" d="M 21,7 1.9999996,26 H 10 l 8,-8 v 8 l 8,-8 v 8 l 4,-4 V 7.1 L 21,17 Z"/>
+ <path style="fill:#428bca;fill-rule:evenodd;stroke-width:0.0495316;;" d="M 21,6 2,25 h 8 l 8,-8 v 8 l 8,-8 v 8 l 4,-4 V 7 l -9,9 z"/>
+ <path style="opacity:0.2;fill:#ffffff;fill-rule:evenodd;stroke-width:0.05;;" d="M 21,6 2,25 H 3 L 21,7 Z m 9,1 -9,9 v 1 l 9,-9 z"/>
+</svg>

--- a/Papirus/48x48/apps/mame.svg
+++ b/Papirus/48x48/apps/mame.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="48" width="48" version="1.1" viewBox="0 0 48 48">
+ <path style="fill-opacity:0.2;fill-rule:evenodd;stroke-width:0.07075942;;" d="M 31,12 4,39 H 15 L 27,27 V 39 L 37.964519,28.011827 38,39 44,33 V 12 L 31,26 Z"/>
+ <path style="fill:#428bca;fill-rule:evenodd;stroke-width:0.07075942;;" d="M 31,11 4,38 H 15 L 27,26 V 38 L 37.964519,27.011827 38,38 44,32 V 11 L 31,25 Z"/>
+ <path style="opacity:0.2;fill:#ffffff;fill-rule:evenodd;stroke-width:0.1;;" d="M 31,11 4.0000003,38 h 1 L 31,12 Z m 13,0 -13,14 v 1 L 44,12 Z"/>
+</svg>

--- a/Papirus/64x64/apps/mame.svg
+++ b/Papirus/64x64/apps/mame.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="64" viewBox="0 0 64 64" width="64" version="1.1">
+ <path style="fill-opacity:0.2;fill-rule:evenodd;stroke-width:0.1;;" d="M 41,13 3,51 H 18 L 35,34 V 51 L 51,35 V 51 L 60.080004,41.920002 60,13 41,32 Z"/>
+ <path style="fill:#428bca;fill-rule:evenodd;stroke-width:0.1;;" d="M 41,12 3,50 H 18 L 35,33 V 50 L 51,34 V 50 L 60.080004,40.920002 60,12 41,31 Z"/>
+ <path style="opacity:0.2;fill:#ffffff;fill-rule:evenodd;stroke-width:0.1;;" d="M 41,12 3,50 H 4 L 41,13 Z m 19,0 -19,19 v 1 L 60,13 Z"/>
+</svg>


### PR DESCRIPTION
Added an icon for the MAME emulator. Very simple, but should blend in better than the original bitmap:
![mame](https://cloud.githubusercontent.com/assets/618978/24816245/38ff8830-1bd8-11e7-9bd0-a7ca8ba60e31.png)
