### PR TITLE
Make medium and low symbolic battery icons different

### DIFF
--- a/Papirus-Dark/22x22/panel/battery-caution-charging.svg
+++ b/Papirus-Dark/22x22/panel/battery-caution-charging.svg
@@ -1,12 +1,106 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-129 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m138 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m135 710.36v2c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-2h-4.4062l-0.59375 1v-1h-5z" id="path8" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g894"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccssssccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-caution.svg
+++ b/Papirus-Dark/22x22/panel/battery-caution.svg
@@ -1,10 +1,106 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <path opacity=".35" style="fill:currentColor" class="ColorScheme-Highlight" d="m13 4v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11-1h3v-1z" id="path4"/>
- <path style="fill:currentColor" class="ColorScheme-Highlight" d="m16 15v2c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-2z" id="path6"/>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g842"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5294e2;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+         style="fill:#5294e2;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-empty-charging.svg
+++ b/Papirus-Dark/22x22/panel/battery-empty-charging.svg
@@ -1,11 +1,94 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-empty-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-153 -695.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m162 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g946"
+     transform="translate(3,3)">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssssccccccccccc" />
+  </g>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-empty.svg
+++ b/Papirus-Dark/22x22/panel/battery-empty.svg
@@ -2,9 +2,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
  <defs id="defs10">
   <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
  </defs>
- <path opacity=".35" style="fill:currentColor" class="ColorScheme-Text" d="m9 4v1h-2-1v1 11c0.00002 1 1 1 1 1h7v-10h2v-2-1h-3v-1h-4z" id="path4"/>
+ <path opacity=".35" style="fill:currentColor" class="ColorScheme-ButtonBackground" d="m9 4v1h-2-1v1 11c0.00002 1 1 1 1 1h7v-10h2v-2-1h-3v-1h-4z" id="path4"/>
  <path style="fill:currentColor" class="ColorScheme-Highlight" d="m15 9v5l0.25 2h1.5l0.25-2v-5zm0 8v2h2v-2z" id="path6"/>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-full-charged.svg
+++ b/Papirus-Dark/22x22/panel/battery-full-charged.svg
@@ -1,11 +1,94 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-full-charged.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-33 -695.36)" id="g4">
-  <path style="fill:currentColor" d="m42 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <path
+     sodipodi:nodetypes="ccccsssscccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path1019"
+     style="fill:#d3dae3;fill-opacity:1"
+     d="m 9.0000002,4 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 H 15 c 0.554,0 1,-0.446 1,-1 V 6 5 H 13 V 4 Z M 11,7 v 3 h 3 l -3,5 V 12 H 8.0000002 Z" />
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-full.svg
+++ b/Papirus-Dark/22x22/panel/battery-full.svg
@@ -2,10 +2,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
  <defs id="defs10">
   <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
  </defs>
  <g transform="translate(-33 -671.36)" id="g4">
-  <path style="fill:currentColor" d="m42 675.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-Text"/>
+  <path style="fill:currentColor" d="m42 675.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-ButtonBackground"/>
  </g>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-good-charging.svg
+++ b/Papirus-Dark/22x22/panel/battery-good-charging.svg
@@ -1,12 +1,109 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-57 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m66 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m63 704.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-5v2h3l-3 5v-3h-3l2.4062-4h-4.4062z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1106"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 H 8 v 3 h 3 L 8,12 V 9 H 5 L 8,4 Z"
+         style="fill:#d3dae3;fill-opacity:1"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-good.svg
+++ b/Papirus-Dark/22x22/panel/battery-good.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-57 -671.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m66 675.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m63 680.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-10z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1053"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 Z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-low-charging.svg
+++ b/Papirus-Dark/22x22/panel/battery-low-charging.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-105 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m114 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m111 708.36v4c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-4h-3.1992l-1.8008 3v-3h-5z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1214"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 9,10 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="cssssccccc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 10 H 9 l -1,2 v -2 z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-low.svg
+++ b/Papirus-Dark/22x22/panel/battery-low.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-105 -671.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m118 675.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m121 684.36v4c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-4z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1160"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -4 z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/22x22/panel/battery-medium-charging.svg
+++ b/Papirus-Dark/22x22/panel/battery-medium-charging.svg
@@ -1,1 +1,111 @@
-battery-good-charging.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1322"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 L 6,7 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="cssssccccccc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 H 11 L 8,12 V 9 H 5 L 6,7 Z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Papirus-Dark/22x22/panel/battery-medium.svg
+++ b/Papirus-Dark/22x22/panel/battery-medium.svg
@@ -1,1 +1,111 @@
-battery-good.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1268"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 Z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Papirus-Dark/24x24/panel/battery-caution-charging.svg
+++ b/Papirus-Dark/24x24/panel/battery-caution-charging.svg
@@ -1,12 +1,110 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.450819"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-128 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m138 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m135 712.36v2c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-2h-4.4062l-0.59375 1v-1h-5z" id="path8" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g908"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccssssccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-caution.svg
+++ b/Papirus-Dark/24x24/panel/battery-caution.svg
@@ -1,12 +1,110 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.231517"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-128 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" class="ColorScheme-Highlight" d="m142 677.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6"/>
-  <path style="fill:currentColor" class="ColorScheme-Highlight" d="m145 688.36v2c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-2z" id="path8"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g854"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+           style="opacity:0.35;fill:#5294e2;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+           style="fill:#5294e2;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-empty-charging.svg
+++ b/Papirus-Dark/24x24/panel/battery-empty-charging.svg
@@ -1,11 +1,98 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-empty-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.450819"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-152 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m162 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g960"
+       transform="translate(60,700.36)">
+      <path
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         id="path4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccssssccccccccccc" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-empty.svg
+++ b/Papirus-Dark/24x24/panel/battery-empty.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
  <defs id="defs12">
   <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
  </defs>
  <g transform="translate(-176 -672.36)" id="g4">

--- a/Papirus-Dark/24x24/panel/battery-full-charged.svg
+++ b/Papirus-Dark/24x24/panel/battery-full-charged.svg
@@ -1,11 +1,98 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-full-charged.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.450819"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-32 -696.36)" id="g4">
-  <path style="fill:currentColor" d="m42 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)">
+      <path
+         d="m 6.00002,1 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 3 2 h -3 V 1 Z m 2,3 v 3 h 3 l -3,5 V 9 h -3 z"
+         style="fill:#d3dae3;fill-opacity:1"
+         id="path1019"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccsssscccccccccccc" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-full.svg
+++ b/Papirus-Dark/24x24/panel/battery-full.svg
@@ -2,10 +2,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
  <defs id="defs10">
   <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
  </defs>
  <g transform="translate(-32 -672.36)" id="g4">
-  <path style="fill:currentColor" d="m42 677.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-Text"/>
+  <path style="fill:currentColor" d="m42 677.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-ButtonBackground"/>
  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-good-charging.svg
+++ b/Papirus-Dark/24x24/panel/battery-good-charging.svg
@@ -1,12 +1,112 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-56 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m66 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m63 706.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-5v2h3l-3 5v-3h-3l2.4062-4h-4.4062z" id="path8" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1223"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 H 8 v 3 h 3 L 8,12 V 9 H 5 L 8,4 Z"
+           style="fill:#d3dae3;fill-opacity:1"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-good.svg
+++ b/Papirus-Dark/24x24/panel/battery-good.svg
@@ -1,12 +1,114 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-56 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m66 677.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m63 682.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-10z" id="path8" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1170"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 Z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-low-charging.svg
+++ b/Papirus-Dark/24x24/panel/battery-low-charging.svg
@@ -1,12 +1,114 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-104 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m114 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m111 710.36v4c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-4h-3.1992l-1.8008 3v-3h-5z" id="path8" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1341"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 9,10 8,12 V 9 H 5 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="cssssccccc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 10 H 9 l -1,2 v -2 z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-low.svg
+++ b/Papirus-Dark/24x24/panel/battery-low.svg
@@ -1,12 +1,114 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-104 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m118 677.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m121 686.36v4c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-4z" id="path8" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1287"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -4 z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/24x24/panel/battery-medium-charging.svg
+++ b/Papirus-Dark/24x24/panel/battery-medium-charging.svg
@@ -1,1 +1,114 @@
-battery-good-charging.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1445"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 L 6,7 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="cssssccccccc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 H 11 L 8,12 V 9 H 5 L 6,7 Z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Papirus-Dark/24x24/panel/battery-medium.svg
+++ b/Papirus-Dark/24x24/panel/battery-medium.svg
@@ -1,1 +1,114 @@
-battery-good.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1395"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 Z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Papirus-Dark/24x24/panel/battery-missing.svg
+++ b/Papirus-Dark/24x24/panel/battery-missing.svg
@@ -2,10 +2,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
  <defs id="defs10">
   <style type="text/css" id="current-color-scheme">
-   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; }
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
  </defs>
  <g transform="translate(-152 -672.36)" id="g4">
-  <path style="fill:currentColor" d="m162 677.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1h-4zm2 4c1.1046 0 2 0.89543 2 2s-0.89543 2-2 2v1h-1v-2h1c0.55229 0 1-0.44772 1-1s-0.44771-1-1-1c-0.55228 0-1 0.44772-1 1h-1c0-1.1046 0.89543-2 2-2zm-1 6h1v1h-1v-1z" id="path6" class="ColorScheme-Text"/>
+  <path style="fill:currentColor" d="m162 677.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1h-4zm2 4c1.1046 0 2 0.89543 2 2s-0.89543 2-2 2v1h-1v-2h1c0.55229 0 1-0.44772 1-1s-0.44771-1-1-1c-0.55228 0-1 0.44772-1 1h-1c0-1.1046 0.89543-2 2-2zm-1 6h1v1h-1v-1z" id="path6" class="ColorScheme-ButtonBackground"/>
  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-caution-charging-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-caution-charging-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-caution-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-465.00018,395)">
-  <path d="m 471.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="opacity:0.35;fill:#d3dae3;fill-opacity:1;"/>
-  <path d="m 468.0002,-383 0,2 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-2 -4.40625,0 -0.59375,1 0,-1 -5,0 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssssccccccccccc" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1"
+       d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-caution-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-caution-symbolic.svg
@@ -1,7 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <g transform="translate(-325.00019,395)">
-  <path class="warning" d="m 335.00017,-394 0,1 3.00003,0 c 0,0 -3e-5,0.446 -3e-5,1 l 0,11 c 0,0.554 -0.446,1 -1,1 l -8,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-11 c 0,-0.554 3e-5,-1 3e-5,-1 l 2.99997,0 0,-1 z" style="opacity:0.35;fill:#5294e2;fill-opacity:1;"/>
-  <path class="warning" d="m 338.00017,-383 0,2 c 0,0.554 -0.446,1 -1,1 l -8,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-2 z" style="fill:#5294e2;fill-opacity:1;"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-caution-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
+  Paper Symbolic Icon Theme
+ </title>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#5294e2;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccc" />
+    <path
+       style="fill:#5294e2;fill-opacity:1"
+       d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-empty-charging-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-empty-charging-symbolic.svg
@@ -1,9 +1,80 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-empty-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-485.00018,395)">
-  <path d="m 491.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="opacity:0.35;fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssssccccccccccc" />
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-full-charged-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-full-charged-symbolic.svg
@@ -1,9 +1,98 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
-  Paper Symbolic Icon Theme
- </title>
- <g transform="translate(-385.00018,395)">
-  <path d="m 391.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-full-charged.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.450819"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)">
+      <path
+         d="m 6.00002,1 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 3 2 h -3 V 1 Z m 2,3 v 3 h 3 l -3,5 V 9 h -3 z"
+         style="fill:#d3dae3;fill-opacity:1"
+         id="path1019"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccsssscccccccccccc" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-full-charging-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-full-charging-symbolic.svg
@@ -1,9 +1,98 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
-  Paper Symbolic Icon Theme
- </title>
- <g transform="translate(-385.00018,395)">
-  <path d="m 391.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-full-charged.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.450819"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)">
+      <path
+         d="m 6.00002,1 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 3 2 h -3 V 1 Z m 2,3 v 3 h 3 l -3,5 V 9 h -3 z"
+         style="fill:#d3dae3;fill-opacity:1"
+         id="path1019"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccsssscccccccccccc" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-good-charging-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-good-charging-symbolic.svg
@@ -1,10 +1,76 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-good-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-425.00018,395)">
-  <path d="m 431.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="opacity:0.35;fill:#d3dae3;fill-opacity:1;"/>
-  <path d="m 428.0002,-389 0,8 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 -5,0 0,2 3,0 -3,5 0,-3 -3,0 2.40625,-4 -4.40625,0 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6 1 L 6 2 L 3 2 L 3 14 C 3 14.554 3.446 15 4 15 L 12 15 C 12.554 15 13 14.554 13 14 L 13 2 L 10 2 L 10 1 L 6 1 z M 8 4 L 8 7 L 11 7 L 8 12 L 8 9 L 5 9 L 8 4 z "
+       transform="translate(425.00018,-395)"
+       id="path4" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1"
+       d="M 3 4 L 3 14 C 3 14.554 3.446 15 4 15 L 12 15 C 12.554 15 13 14.554 13 14 L 13 4 L 8 4 L 8 7 L 11 7 L 8 12 L 8 9 L 5 9 L 8 4 L 3 4 z "
+       transform="translate(425.00018,-395)"
+       id="path6" />
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-good-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-good-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-good-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-285.00018,395)">
-  <path d="m 291.0002,-394 0,1 -3,0 0,1 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 0,-1 -3,0 0,-1 z" style="opacity:0.35;fill:#d3dae3;fill-opacity:1;"/>
-  <path d="m 288.0002,-389 0,8 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 -10,0 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccc" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1"
+       d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 Z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-low-charging-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-low-charging-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-low-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-445.00018,395)">
-  <path d="m 451.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="opacity:0.35;fill:#d3dae3;fill-opacity:1;"/>
-  <path d="m 448.0002,-387 0,6 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-6 -2,0 -3,5 0,-3 -3,0 1.1875,-2 -3.1875,0 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 9,10 8,12 V 9 H 5 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccccccccccc" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1"
+       d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 10 H 9 l -1,2 v -2 z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssssccccc" />
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-low-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-low-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-low-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-305.00019,395)">
-  <path d="m 315.00017,-394 0,1 3.00003,0 c 0,0 -3e-5,0.446 -3e-5,1 l 0,11 c 0,0.554 -0.446,1 -1,1 l -8,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-11 c 0,-0.554 3e-5,-1 3e-5,-1 l 2.99997,0 0,-1 z" style="opacity:0.35;fill:#d3dae3;fill-opacity:1;"/>
-  <path d="m 318.00017,-387 0,6 c 0,0.554 -0.446,1 -1,1 l -8,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-6 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccc" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1"
+       d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -4 z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-medium-charging-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-medium-charging-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-medium-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-385.0002,554.99854)">
-  <path d="m 391.00022,-553.99854 0,1 -3,0 0,1 0,8 2,-1 3,-5 0,3 5,0 0,-5 0,-1 -3,0 0,-1 z" style="opacity:0.35;fill:#d3dae3;fill-opacity:1;"/>
-  <path d="m 388.00022,-546.99854 0,6 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-6 -2,0 -3,5 0,-3 -3,0 1.20313,-2 -3.20313,0 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 L 6,7 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccccccccccc" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1"
+       d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 H 11 L 8,12 V 9 H 5 L 6,7 Z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssssccccccc" />
+  </g>
 </svg>

--- a/Papirus-Dark/symbolic/status/battery-medium-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-medium-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-medium-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-385.0002,574.99854)">
-  <path d="m 391.00022,-573.99854 0,1 -3,0 0,1 0,6 10,0 0,-6 0,-1 -3,0 0,-1 z" style="opacity:0.35;fill:#d3dae3;fill-opacity:1;"/>
-  <path d="m 388.00022,-566.99854 0,6 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-6 z" style="fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccc" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1"
+       d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 Z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus-Light/22x22/panel/battery-caution-charging.svg
+++ b/Papirus-Light/22x22/panel/battery-caution-charging.svg
@@ -1,12 +1,106 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-129 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m138 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m135 710.36v2c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-2h-4.4062l-0.59375 1v-1h-5z" id="path8" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g892"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccssssccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/22x22/panel/battery-caution.svg
+++ b/Papirus-Light/22x22/panel/battery-caution.svg
@@ -1,10 +1,105 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <path opacity=".35" style="fill:currentColor" class="ColorScheme-Highlight" d="m13 4v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11-1h3v-1z" id="path4"/>
- <path style="fill:currentColor" class="ColorScheme-Highlight" d="m16 15v2c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-2z" id="path6"/>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g840"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5294e2;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+         style="fill:#5294e2;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/22x22/panel/battery-empty-charging.svg
+++ b/Papirus-Light/22x22/panel/battery-empty-charging.svg
@@ -1,11 +1,94 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-empty-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-153 -695.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m162 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g944"
+     transform="translate(3,3)">
+    <path
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssssccccccccccc" />
+  </g>
 </svg>

--- a/Papirus-Light/22x22/panel/battery-full-charged.svg
+++ b/Papirus-Light/22x22/panel/battery-full-charged.svg
@@ -1,11 +1,94 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-full-charged.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-33 -695.36)" id="g4">
-  <path style="fill:currentColor" d="m42 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <path
+     sodipodi:nodetypes="ccccsssscccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path1019"
+     style="fill:#5c616c;fill-opacity:1"
+     d="m 9.0000003,4 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 H 15 c 0.554,0 1,-0.446 1,-1 V 6 5 H 13 V 4 Z M 11,7 v 3 h 3 l -3,5 V 12 H 8.0000003 Z" />
 </svg>

--- a/Papirus-Light/22x22/panel/battery-good-charging.svg
+++ b/Papirus-Light/22x22/panel/battery-good-charging.svg
@@ -1,12 +1,109 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-57 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m66 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m63 704.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-5v2h3l-3 5v-3h-3l2.4062-4h-4.4062z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1104"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 H 8 v 3 h 3 L 8,12 V 9 H 5 L 8,4 Z"
+         style="fill:#5c616c;fill-opacity:1"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/22x22/panel/battery-good.svg
+++ b/Papirus-Light/22x22/panel/battery-good.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-57 -671.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m66 675.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m63 680.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-10z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1051"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 Z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/22x22/panel/battery-low-charging.svg
+++ b/Papirus-Light/22x22/panel/battery-low-charging.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-105 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m114 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m111 708.36v4c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-4h-3.1992l-1.8008 3v-3h-5z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1212"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 9,10 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="cssssccccc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 10 H 9 l -1,2 v -2 z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/22x22/panel/battery-low.svg
+++ b/Papirus-Light/22x22/panel/battery-low.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-105 -671.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m118 675.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m121 684.36v4c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-4z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1158"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -4 z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/22x22/panel/battery-medium-charging.svg
+++ b/Papirus-Light/22x22/panel/battery-medium-charging.svg
@@ -1,1 +1,111 @@
-battery-good-charging.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
+  </style>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1320"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 L 6,7 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="cssssccccccc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 H 11 L 8,12 V 9 H 5 L 6,7 Z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Papirus-Light/22x22/panel/battery-medium.svg
+++ b/Papirus-Light/22x22/panel/battery-medium.svg
@@ -1,1 +1,111 @@
-battery-good.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="10.923899"
+     inkscape:cy="6.563421"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
+  </style>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1266"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 Z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Papirus-Light/24x24/panel/battery-caution-charging.svg
+++ b/Papirus-Light/24x24/panel/battery-caution-charging.svg
@@ -1,12 +1,106 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-128 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m138 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m135 712.36v2c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-2h-4.4062l-0.59375 1v-1h-5z" id="path8" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g894"
+     transform="translate(4,4)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccssssccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/24x24/panel/battery-caution.svg
+++ b/Papirus-Light/24x24/panel/battery-caution.svg
@@ -1,12 +1,106 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-128 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" class="ColorScheme-Highlight" d="m142 677.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6"/>
-  <path style="fill:currentColor" class="ColorScheme-Highlight" d="m145 688.36v2c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-2z" id="path8"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g840"
+     transform="translate(4,4)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5294e2;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+         style="fill:#5294e2;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/24x24/panel/battery-empty-charging.svg
+++ b/Papirus-Light/24x24/panel/battery-empty-charging.svg
@@ -1,11 +1,94 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-empty-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-152 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m162 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g946"
+     transform="translate(4,4)">
+    <path
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssssccccccccccc" />
+  </g>
 </svg>

--- a/Papirus-Light/24x24/panel/battery-full-charged.svg
+++ b/Papirus-Light/24x24/panel/battery-full-charged.svg
@@ -1,11 +1,94 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-full-charged.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-32 -696.36)" id="g4">
-  <path style="fill:currentColor" d="m42 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <path
+     sodipodi:nodetypes="ccccsssscccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path1019"
+     style="fill:#5c616c;fill-opacity:1"
+     d="m 9.9999996,5 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 H 16 c 0.554,0 1,-0.446 1,-1 V 7 6 H 14 V 5 Z M 12,8 v 3 h 3 l -3,5 V 13 H 8.9999996 Z" />
 </svg>

--- a/Papirus-Light/24x24/panel/battery-good-charging.svg
+++ b/Papirus-Light/24x24/panel/battery-good-charging.svg
@@ -1,12 +1,109 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-56 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m66 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m63 706.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-5v2h3l-3 5v-3h-3l2.4062-4h-4.4062z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1106"
+     transform="translate(4,4)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 H 8 v 3 h 3 L 8,12 V 9 H 5 L 8,4 Z"
+         style="fill:#5c616c;fill-opacity:1"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/24x24/panel/battery-good.svg
+++ b/Papirus-Light/24x24/panel/battery-good.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-56 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m66 677.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m63 682.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-10z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1053"
+     transform="translate(4,4)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 Z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/24x24/panel/battery-low-charging.svg
+++ b/Papirus-Light/24x24/panel/battery-low-charging.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-104 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m114 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m111 710.36v4c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-4h-3.1992l-1.8008 3v-3h-5z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1214"
+     transform="translate(4,4)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 9,10 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="cssssccccc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 10 H 9 l -1,2 v -2 z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/24x24/panel/battery-low.svg
+++ b/Papirus-Light/24x24/panel/battery-low.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
   </style>
- </defs>
- <g transform="translate(-104 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m118 677.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6" class="ColorScheme-Text"/>
-  <path style="fill:currentColor" d="m121 686.36v4c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-4z" id="path8" class="ColorScheme-Text"/>
- </g>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1160"
+     transform="translate(4,4)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -4 z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus-Light/24x24/panel/battery-medium-charging.svg
+++ b/Papirus-Light/24x24/panel/battery-medium-charging.svg
@@ -1,1 +1,111 @@
-battery-good-charging.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
+  </style>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1322"
+     transform="translate(4,4)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 L 6,7 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="cssssccccccc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 H 11 L 8,12 V 9 H 5 L 6,7 Z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Papirus-Light/24x24/panel/battery-medium.svg
+++ b/Papirus-Light/24x24/panel/battery-medium.svg
@@ -1,1 +1,111 @@
-battery-good.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="41.916667"
+     inkscape:cx="11.506849"
+     inkscape:cy="13.85837"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="0,1"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; }
+  </style>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#5c616c; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1268"
+     transform="translate(4,4)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5c616c;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 Z"
+         style="fill:#5c616c;fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Papirus/22x22/panel/battery-caution-charging.svg
+++ b/Papirus/22x22/panel/battery-caution-charging.svg
@@ -1,12 +1,106 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-129 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m138 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m135 710.36v2c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-2h-4.4062l-0.59375 1v-1h-5z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g894"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccssssccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus/22x22/panel/battery-caution.svg
+++ b/Papirus/22x22/panel/battery-caution.svg
@@ -1,10 +1,106 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <path opacity=".35" style="fill:currentColor" class="ColorScheme-Highlight" d="m13 4v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11-1h3v-1z" id="path4"/>
- <path style="fill:currentColor" class="ColorScheme-Highlight" d="m16 15v2c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-2z" id="path6"/>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g842"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#5294e2;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+         style="fill:#5294e2;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus/22x22/panel/battery-empty-charging.svg
+++ b/Papirus/22x22/panel/battery-empty-charging.svg
@@ -1,11 +1,94 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-empty-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-153 -695.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m162 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g946"
+     transform="translate(3,3)">
+    <path
+       style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssssccccccccccc" />
+  </g>
 </svg>

--- a/Papirus/22x22/panel/battery-full-charged.svg
+++ b/Papirus/22x22/panel/battery-full-charged.svg
@@ -1,11 +1,94 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-full-charged.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-33 -695.36)" id="g4">
-  <path style="fill:currentColor" d="m42 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <path
+     sodipodi:nodetypes="ccccsssscccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path1019"
+     style="fill:#d3dae3;fill-opacity:1"
+     d="m 9.0000002,4 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 H 15 c 0.554,0 1,-0.446 1,-1 V 6 5 H 13 V 4 Z M 11,7 v 3 h 3 l -3,5 V 12 H 8.0000002 Z" />
 </svg>

--- a/Papirus/22x22/panel/battery-good-charging.svg
+++ b/Papirus/22x22/panel/battery-good-charging.svg
@@ -1,12 +1,109 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-57 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m66 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m63 704.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-5v2h3l-3 5v-3h-3l2.4062-4h-4.4062z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1106"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 H 8 v 3 h 3 L 8,12 V 9 H 5 L 8,4 Z"
+         style="fill:#d3dae3;fill-opacity:1"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
 </svg>

--- a/Papirus/22x22/panel/battery-good.svg
+++ b/Papirus/22x22/panel/battery-good.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-57 -671.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m66 675.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m63 680.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-10z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1053"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 Z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus/22x22/panel/battery-low-charging.svg
+++ b/Papirus/22x22/panel/battery-low-charging.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-105 -695.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m114 699.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m111 708.36v4c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-4h-3.1992l-1.8008 3v-3h-5z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1214"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 9,10 8,12 V 9 H 5 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="cssssccccc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 10 H 9 l -1,2 v -2 z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus/22x22/panel/battery-low.svg
+++ b/Papirus/22x22/panel/battery-low.svg
@@ -1,12 +1,111 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-105 -671.36)" id="g4">
-  <path opacity=".3" style="fill:currentColor" d="m118 675.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m121 684.36v4c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-4z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1160"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -4 z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
 </svg>

--- a/Papirus/22x22/panel/battery-medium-charging.svg
+++ b/Papirus/22x22/panel/battery-medium-charging.svg
@@ -1,1 +1,111 @@
-battery-good-charging.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1322"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 L 6,7 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="cssssccccccc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 H 11 L 8,12 V 9 H 5 L 6,7 Z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Papirus/22x22/panel/battery-medium.svg
+++ b/Papirus/22x22/panel/battery-medium.svg
@@ -1,1 +1,111 @@
-battery-good.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   width="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview7"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.863636"
+     inkscape:cx="9.5901928"
+     inkscape:cy="11.751649"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid819" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="0,1"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6,18"
+       orientation="1,0"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16,4"
+       orientation="1,0"
+       id="guide827"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs10">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+    <style
+       id="current-color-scheme-3"
+       type="text/css">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     style="enable-background:new"
+     id="g1268"
+     transform="translate(3,3)">
+    <g
+       id="g8"
+       transform="translate(-425.00018,395)">
+      <path
+         sodipodi:nodetypes="cccsssscccc"
+         inkscape:connector-curvature="0"
+         id="path4"
+         transform="translate(425.00018,-395)"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="csssscc"
+         inkscape:connector-curvature="0"
+         id="path6"
+         transform="translate(425.00018,-395)"
+         d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 Z"
+         style="fill:#d3dae3;fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Papirus/24x24/panel/battery-caution-charging.svg
+++ b/Papirus/24x24/panel/battery-caution-charging.svg
@@ -1,12 +1,110 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.450819"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-128 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m138 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m135 712.36v2c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-2h-4.4062l-0.59375 1v-1h-5z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g908"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccssssccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus/24x24/panel/battery-caution.svg
+++ b/Papirus/24x24/panel/battery-caution.svg
@@ -1,12 +1,110 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-caution.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.231517"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-128 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" class="ColorScheme-Highlight" d="m142 677.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6"/>
-  <path style="fill:currentColor" class="ColorScheme-Highlight" d="m145 688.36v2c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-2z" id="path8"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g854"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+           style="opacity:0.35;fill:#5294e2;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+           style="fill:#5294e2;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus/24x24/panel/battery-empty-charging.svg
+++ b/Papirus/24x24/panel/battery-empty-charging.svg
@@ -1,11 +1,98 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-empty-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.450819"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-152 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m162 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g960"
+       transform="translate(60,700.36)">
+      <path
+         style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+         d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+         id="path4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccssssccccccccccc" />
+    </g>
+  </g>
 </svg>

--- a/Papirus/24x24/panel/battery-full-charged.svg
+++ b/Papirus/24x24/panel/battery-full-charged.svg
@@ -1,11 +1,98 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs10">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-full-charged.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.450819"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-32 -696.36)" id="g4">
-  <path style="fill:currentColor" d="m42 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)">
+      <path
+         d="m 6.00002,1 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 3 2 h -3 V 1 Z m 2,3 v 3 h 3 l -3,5 V 9 h -3 z"
+         style="fill:#d3dae3;fill-opacity:1"
+         id="path1019"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccsssscccccccccccc" />
+    </g>
+  </g>
 </svg>

--- a/Papirus/24x24/panel/battery-good-charging.svg
+++ b/Papirus/24x24/panel/battery-good-charging.svg
@@ -1,12 +1,112 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-56 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m66 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m63 706.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-5v2h3l-3 5v-3h-3l2.4062-4h-4.4062z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1223"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 H 8 v 3 h 3 L 8,12 V 9 H 5 L 8,4 Z"
+           style="fill:#d3dae3;fill-opacity:1"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus/24x24/panel/battery-good.svg
+++ b/Papirus/24x24/panel/battery-good.svg
@@ -1,12 +1,114 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-good.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-56 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m66 677.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m63 682.36v8c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-8h-10z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1170"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 Z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus/24x24/panel/battery-low-charging.svg
+++ b/Papirus/24x24/panel/battery-low-charging.svg
@@ -1,12 +1,114 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-104 -696.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m114 701.36v1h-3v12c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-12h-3v-1zm2 4v3h3l-3 5v-3h-3z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m111 710.36v4c0 0.554 0.446 1 1 1h8c0.554 0 1-0.446 1-1v-4h-3.1992l-1.8008 3v-3h-5z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1341"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 9,10 8,12 V 9 H 5 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="cssssccccc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 10 H 9 l -1,2 v -2 z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus/24x24/panel/battery-low.svg
+++ b/Papirus/24x24/panel/battery-low.svg
@@ -1,12 +1,114 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" version="1.1" id="svg2">
- <defs id="defs12">
-  <style type="text/css" id="current-color-scheme">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-low.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
    .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
   </style>
- </defs>
- <g transform="translate(-104 -672.36)" id="g4">
-  <path opacity=".35" style="fill:currentColor" d="m118 677.36v1h3s-0.00003 0.446-0.00003 1v11c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-11c0-0.554 0.00003-1 0.00003-1h3v-1z" id="path6" class="ColorScheme-ButtonBackground"/>
-  <path style="fill:currentColor" d="m121 686.36v4c0 0.554-0.446 1-1 1h-8c-0.554 0-1-0.446-1-1v-4z" id="path8" class="ColorScheme-ButtonBackground"/>
- </g>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1287"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -4 z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Papirus/24x24/panel/battery-medium-charging.svg
+++ b/Papirus/24x24/panel/battery-medium-charging.svg
@@ -1,1 +1,114 @@
-battery-good-charging.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium-charging.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1445"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 L 6,7 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="cssssccccccc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 H 11 L 8,12 V 9 H 5 L 6,7 Z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Papirus/24x24/panel/battery-medium.svg
+++ b/Papirus/24x24/panel/battery-medium.svg
@@ -1,1 +1,114 @@
-battery-good.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="battery-medium.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="1376"
+     id="namedview8"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.639559"
+     inkscape:cx="10.67012"
+     inkscape:cy="9.4289264"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+    <sodipodi:guide
+       position="7,19"
+       orientation="1,0"
+       id="guide819"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="1,0"
+       id="guide821"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,19"
+       orientation="0,1"
+       id="guide823"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17,5"
+       orientation="0,1"
+       id="guide825"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs12">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#5c616c; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+  </style>
+  </defs>
+  <g
+     transform="translate(-56 -696.36)"
+     id="g4">
+    <g
+       style="enable-background:new"
+       id="g1033"
+       transform="translate(59.99998,700.36)" />
+    <g
+       style="enable-background:new"
+       id="g1395"
+       transform="translate(60,700.36)">
+      <g
+         id="g8"
+         transform="translate(-425.00018,395)">
+        <path
+           sodipodi:nodetypes="cccsssscccc"
+           inkscape:connector-curvature="0"
+           id="path4"
+           transform="translate(425.00018,-395)"
+           d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+           style="opacity:0.35;fill:#d3dae3;fill-opacity:1" />
+        <path
+           sodipodi:nodetypes="csssscc"
+           inkscape:connector-curvature="0"
+           id="path6"
+           transform="translate(425.00018,-395)"
+           d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 Z"
+           style="fill:#d3dae3;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Papirus/symbolic/status/battery-caution-charging-symbolic.svg
+++ b/Papirus/symbolic/status/battery-caution-charging-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-caution-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-465.00018,395)">
-  <path d="m 471.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="opacity:0.35;fill:#5c616c;fill-opacity:1;"/>
-  <path d="m 468.0002,-383 0,2 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-2 -4.40625,0 -0.59375,1 0,-1 -5,0 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssssccccccccccc" />
+    <path
+       style="fill:#5c616c;fill-opacity:1"
+       d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-caution-symbolic.svg
+++ b/Papirus/symbolic/status/battery-caution-symbolic.svg
@@ -1,7 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <g transform="translate(-325.00019,395)">
-  <path class="warning" d="m 335.00017,-394 0,1 3.00003,0 c 0,0 -3e-5,0.446 -3e-5,1 l 0,11 c 0,0.554 -0.446,1 -1,1 l -8,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-11 c 0,-0.554 3e-5,-1 3e-5,-1 l 2.99997,0 0,-1 z" style="opacity:0.35;fill:#5294e2;fill-opacity:1;"/>
-  <path class="warning" d="m 338.00017,-383 0,2 c 0,0.554 -0.446,1 -1,1 l -8,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-2 z" style="fill:#5294e2;fill-opacity:1;"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-caution-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
+  Paper Symbolic Icon Theme
+ </title>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#5294e2;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccc" />
+    <path
+       style="fill:#5294e2;fill-opacity:1"
+       d="m 3,12 v 2 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -2 z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-empty-charging-symbolic.svg
+++ b/Papirus/symbolic/status/battery-empty-charging-symbolic.svg
@@ -1,9 +1,80 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-empty-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-485.00018,395)">
-  <path d="m 491.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="opacity:0.35;fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssssccccccccccc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-full-charged-symbolic.svg
+++ b/Papirus/symbolic/status/battery-full-charged-symbolic.svg
@@ -1,9 +1,69 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg8"
+   sodipodi:docname="battery-full-charged-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8">
+    <inkscape:grid
+       type="xygrid"
+       id="grid821" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-385.00018,395)">
-  <path d="m 391.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-385.00018,395)"
+     id="g6">
+    <path
+       d="m 391.0002,-394 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -11 -1 h -3 v -1 z m 1.99998,3 v 3 h 3 l -3,5 v -3 h -3 z"
+       style="fill:#5c616c;fill-opacity:1"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccsssscccccccccccc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-full-charging-symbolic.svg
+++ b/Papirus/symbolic/status/battery-full-charging-symbolic.svg
@@ -1,9 +1,69 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg8"
+   sodipodi:docname="battery-full-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8">
+    <inkscape:grid
+       type="xygrid"
+       id="grid821" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-385.00018,395)">
-  <path d="m 391.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-385.00018,395)"
+     id="g6">
+    <path
+       d="m 391.0002,-394 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -11 -1 h -3 v -1 z m 1.99998,3 v 3 h 3 l -3,5 v -3 h -3 z"
+       style="fill:#5c616c;fill-opacity:1"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccsssscccccccccccc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-good-charging-symbolic.svg
+++ b/Papirus/symbolic/status/battery-good-charging-symbolic.svg
@@ -1,10 +1,76 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-good-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-425.00018,395)">
-  <path d="m 431.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="opacity:0.35;fill:#5c616c;fill-opacity:1;"/>
-  <path d="m 428.0002,-389 0,8 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 -5,0 0,2 3,0 -3,5 0,-3 -3,0 2.40625,-4 -4.40625,0 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6 1 L 6 2 L 3 2 L 3 14 C 3 14.554 3.446 15 4 15 L 12 15 C 12.554 15 13 14.554 13 14 L 13 2 L 10 2 L 10 1 L 6 1 z M 8 4 L 8 7 L 11 7 L 8 12 L 8 9 L 5 9 L 8 4 z "
+       transform="translate(425.00018,-395)"
+       id="path4" />
+    <path
+       style="fill:#5c616c;fill-opacity:1"
+       d="M 3 4 L 3 14 C 3 14.554 3.446 15 4 15 L 12 15 C 12.554 15 13 14.554 13 14 L 13 4 L 8 4 L 8 7 L 11 7 L 8 12 L 8 9 L 5 9 L 8 4 L 3 4 z "
+       transform="translate(425.00018,-395)"
+       id="path6" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-good-symbolic.svg
+++ b/Papirus/symbolic/status/battery-good-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-good-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-285.00018,395)">
-  <path d="m 291.0002,-394 0,1 -3,0 0,1 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 0,-1 -3,0 0,-1 z" style="opacity:0.35;fill:#5c616c;fill-opacity:1;"/>
-  <path d="m 288.0002,-389 0,8 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 -10,0 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccc" />
+    <path
+       style="fill:#5c616c;fill-opacity:1"
+       d="m 3,4 v 10 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 4 Z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-low-charging-symbolic.svg
+++ b/Papirus/symbolic/status/battery-low-charging-symbolic.svg
@@ -1,10 +1,78 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-low-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="7.7066977"
+     inkscape:cy="7.5138496"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-445.00018,395)">
-  <path d="m 451.0002,-394 0,1 -3,0 c 0,0 0,0.446 0,1 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-11 c 0,-0.554 0,-1 0,-1 l -3,0 0,-1 z m 2,4 0,3 3,0 -3,5 0,-3 -3,0 z" style="opacity:0.35;fill:#5c616c;fill-opacity:1;"/>
-  <path d="m 448.0002,-387 0,6 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-6 -2,0 -3,5 0,-3 -3,0 1.1875,-2 -3.1875,0 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-445.00018,395)"
+     id="g8">
+    <path
+       d="m 451.0002,-394 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -11 -1 h -3 v -1 z m 2,4 v 3 h 3 l -1.00002,2 -1.99998,3 v -3 h -3 z"
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccssssccccccccccccc" />
+    <path
+       d="m 448.00018,-385 2e-5,4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 l -2e-5,-4 h -3 l -1.99998,3 -2e-5,-3 h -3 z"
+       style="fill:#5c616c;fill-opacity:1"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscccccc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-low-charging-symbolic.svg
+++ b/Papirus/symbolic/status/battery-low-charging-symbolic.svg
@@ -45,34 +45,43 @@
      id="namedview12"
      showgrid="true"
      inkscape:zoom="62.875"
-     inkscape:cx="7.7066977"
-     inkscape:cy="7.5138496"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
      inkscape:window-x="0"
      inkscape:window-y="31"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g8">
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
     <inkscape:grid
        type="xygrid"
        id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <title
      id="title2">
   Paper Symbolic Icon Theme
  </title>
   <g
-     transform="translate(-445.00018,395)"
+     transform="translate(-425.00018,395)"
      id="g8">
     <path
-       d="m 451.0002,-394 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -11 -1 h -3 v -1 z m 2,4 v 3 h 3 l -1.00002,2 -1.99998,3 v -3 h -3 z"
        style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 9,10 8,12 V 9 H 5 Z"
+       transform="translate(425.00018,-395)"
        id="path4"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccssssccccccccccccc" />
+       sodipodi:nodetypes="cccsssscccccccccccc" />
     <path
-       d="m 448.00018,-385 2e-5,4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 l -2e-5,-4 h -3 l -1.99998,3 -2e-5,-3 h -3 z"
        style="fill:#5c616c;fill-opacity:1"
+       d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 10 H 9 l -1,2 v -2 z"
+       transform="translate(425.00018,-395)"
        id="path6"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csssscccccc" />
+       sodipodi:nodetypes="cssssccccc" />
   </g>
 </svg>

--- a/Papirus/symbolic/status/battery-low-symbolic.svg
+++ b/Papirus/symbolic/status/battery-low-symbolic.svg
@@ -1,10 +1,78 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-low-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="7.7066977"
+     inkscape:cy="5.5459141"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg10">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-305.00019,395)">
-  <path d="m 315.00017,-394 0,1 3.00003,0 c 0,0 -3e-5,0.446 -3e-5,1 l 0,11 c 0,0.554 -0.446,1 -1,1 l -8,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-11 c 0,-0.554 3e-5,-1 3e-5,-1 l 2.99997,0 0,-1 z" style="opacity:0.35;fill:#5c616c;fill-opacity:1;"/>
-  <path d="m 318.00017,-387 0,6 c 0,0.554 -0.446,1 -1,1 l -8,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-6 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-445.0002,395)"
+     id="g8">
+    <path
+       d="m 451.0002,-394 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -11 -1 h -3 v -1 z"
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccssssccccc" />
+    <path
+       d="m 448.00018,-385 2e-5,4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 l -2e-5,-4 z"
+       style="fill:#5c616c;fill-opacity:1"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-low-symbolic.svg
+++ b/Papirus/symbolic/status/battery-low-symbolic.svg
@@ -45,32 +45,41 @@
      id="namedview12"
      showgrid="true"
      inkscape:zoom="62.875"
-     inkscape:cx="7.7066977"
-     inkscape:cy="5.5459141"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
      inkscape:window-x="0"
      inkscape:window-y="31"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg10">
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
     <inkscape:grid
        type="xygrid"
        id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <title
      id="title2">
   Paper Symbolic Icon Theme
  </title>
   <g
-     transform="translate(-445.0002,395)"
+     transform="translate(-425.00018,395)"
      id="g8">
     <path
-       d="m 451.0002,-394 v 1 h -3 v 1 11 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -11 -1 h -3 v -1 z"
        style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+       transform="translate(425.00018,-395)"
        id="path4"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccssssccccc" />
+       sodipodi:nodetypes="cccsssscccc" />
     <path
-       d="m 448.00018,-385 2e-5,4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 l -2e-5,-4 z"
        style="fill:#5c616c;fill-opacity:1"
+       d="m 3,10 v 4 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 v -4 z"
+       transform="translate(425.00018,-395)"
        id="path6"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="csssscc" />

--- a/Papirus/symbolic/status/battery-medium-charging-symbolic.svg
+++ b/Papirus/symbolic/status/battery-medium-charging-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-medium-charging-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-385.0002,554.99854)">
-  <path d="m 391.00022,-553.99854 0,1 -3,0 0,1 0,8 2,-1 3,-5 0,3 5,0 0,-5 0,-1 -3,0 0,-1 z" style="opacity:0.35;fill:#5c616c;fill-opacity:1;"/>
-  <path d="m 388.00022,-546.99854 0,6 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-6 -2,0 -3,5 0,-3 -3,0 1.20313,-2 -3.20313,0 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z m 2,3 v 3 h 3 L 8,12 V 9 H 5 L 6,7 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccccccccccc" />
+    <path
+       style="fill:#5c616c;fill-opacity:1"
+       d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 H 11 L 8,12 V 9 H 5 L 6,7 Z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssssccccccc" />
+  </g>
 </svg>

--- a/Papirus/symbolic/status/battery-medium-symbolic.svg
+++ b/Papirus/symbolic/status/battery-medium-symbolic.svg
@@ -1,10 +1,87 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg10"
+   sodipodi:docname="battery-medium-symbolic.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="62.875"
+     inkscape:cx="8.1033797"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+    <sodipodi:guide
+       position="9.5427435,8"
+       orientation="0,1"
+       id="guide919"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-385.0002,574.99854)">
-  <path d="m 391.00022,-573.99854 0,1 -3,0 0,1 0,6 10,0 0,-6 0,-1 -3,0 0,-1 z" style="opacity:0.35;fill:#5c616c;fill-opacity:1;"/>
-  <path d="m 388.00022,-566.99854 0,6 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-6 z" style="fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-425.00018,395)"
+     id="g8">
+    <path
+       style="opacity:0.35;fill:#5c616c;fill-opacity:1"
+       d="M 6,1 V 2 H 3 v 12 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 2 H 10 V 1 Z"
+       transform="translate(425.00018,-395)"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssscccc" />
+    <path
+       style="fill:#5c616c;fill-opacity:1"
+       d="m 3,7 v 7 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 7 Z"
+       transform="translate(425.00018,-395)"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+  </g>
 </svg>


### PR DESCRIPTION
The current icons for `battery-medium-symbolic` and `battery-low-symbolic` are identical. This is also true for the charging variants. For the panel icons, the `-good` and `-medium` variants are identical. This creates problems because it makes it difficult for users to tell how much battery they have left without looking for a percentage, as in https://github.com/system76/pop-distro/issues/44

This PR changes the level of fill for all of the battery icons to better visually distinguish between the different levels, and makes the Panel icons match their symbolic variants. It tweaks the positioning of the charging lightning bolt to help ensure good alignment with the pixel grid in all icons.

The new levels on the icons don't precisely match the actual battery percentage reported by Upower, however due to that utility's limited resolution this does ensure higher usability of all of the different icons.