### PR TITLE
Add symlink for Waterfox

### DIFF
--- a/Papirus/16x16/apps/waterfox-icon.svg
+++ b/Papirus/16x16/apps/waterfox-icon.svg
@@ -1,0 +1,1 @@
+waterfox.svg

--- a/Papirus/22x22/apps/waterfox-icon.svg
+++ b/Papirus/22x22/apps/waterfox-icon.svg
@@ -1,0 +1,1 @@
+waterfox.svg

--- a/Papirus/24x24/apps/waterfox-icon.svg
+++ b/Papirus/24x24/apps/waterfox-icon.svg
@@ -1,0 +1,1 @@
+waterfox.svg

--- a/Papirus/32x32/apps/waterfox-icon.svg
+++ b/Papirus/32x32/apps/waterfox-icon.svg
@@ -1,0 +1,1 @@
+waterfox.svg

--- a/Papirus/48x48/apps/waterfox-icon.svg
+++ b/Papirus/48x48/apps/waterfox-icon.svg
@@ -1,0 +1,1 @@
+waterfox.svg

--- a/Papirus/64x64/apps/waterfox-icon.svg
+++ b/Papirus/64x64/apps/waterfox-icon.svg
@@ -1,0 +1,1 @@
+waterfox.svg


### PR DESCRIPTION
I forgot to check the Waterfox menu shortcut. It uses waterfox-bin as its icon.