### PR TITLE
Added symlink for mintreport

### DIFF
--- a/Papirus/16x16/apps/mintreport.svg
+++ b/Papirus/16x16/apps/mintreport.svg
@@ -1,0 +1,1 @@
+mate-system-log.svg

--- a/Papirus/22x22/apps/mintreport.svg
+++ b/Papirus/22x22/apps/mintreport.svg
@@ -1,0 +1,1 @@
+mate-system-log.svg

--- a/Papirus/24x24/apps/mintreport.svg
+++ b/Papirus/24x24/apps/mintreport.svg
@@ -1,0 +1,1 @@
+mate-system-log.svg

--- a/Papirus/32x32/apps/mintreport.svg
+++ b/Papirus/32x32/apps/mintreport.svg
@@ -1,0 +1,1 @@
+mate-system-log.svg

--- a/Papirus/48x48/apps/mintreport.svg
+++ b/Papirus/48x48/apps/mintreport.svg
@@ -1,0 +1,1 @@
+mate-system-log.svg

--- a/Papirus/64x64/apps/mintreport.svg
+++ b/Papirus/64x64/apps/mintreport.svg
@@ -1,0 +1,1 @@
+mate-system-log.svg


### PR DESCRIPTION
Added symlink from mate-system-log.svg to mintreport.svg for the "System Reports" tool added in Linux Mint 18.3.