### PR TITLE
[WP]Add symlink for application-x-raw-disk-image-xz-compressed

### DIFF
--- a/Papirus/16x16/mimetypes/application-x-raw-disk-image-xz-compressed.svg
+++ b/Papirus/16x16/mimetypes/application-x-raw-disk-image-xz-compressed.svg
@@ -1,0 +1,1 @@
+../apps/ark.svg

--- a/Papirus/22x22/mimetypes/application-x-raw-disk-image-xz-compressed.svg
+++ b/Papirus/22x22/mimetypes/application-x-raw-disk-image-xz-compressed.svg
@@ -1,0 +1,1 @@
+../apps/ark.svg

--- a/Papirus/24x24/mimetypes/application-x-raw-disk-image-xz-compressed.svg
+++ b/Papirus/24x24/mimetypes/application-x-raw-disk-image-xz-compressed.svg
@@ -1,0 +1,1 @@
+../apps/ark.svg

--- a/Papirus/32x32/mimetypes/application-x-raw-disk-image-xz-compressed.svg
+++ b/Papirus/32x32/mimetypes/application-x-raw-disk-image-xz-compressed.svg
@@ -1,0 +1,1 @@
+../apps/ark.svg

--- a/Papirus/48x48/mimetypes/application-x-raw-disk-image-xz-compressed.svg
+++ b/Papirus/48x48/mimetypes/application-x-raw-disk-image-xz-compressed.svg
@@ -1,0 +1,1 @@
+../apps/ark.svg

--- a/Papirus/64x64/mimetypes/application-x-raw-disk-image-xz-compressed.svg
+++ b/Papirus/64x64/mimetypes/application-x-raw-disk-image-xz-compressed.svg
@@ -1,0 +1,1 @@
+../apps/ark.svg


### PR DESCRIPTION
Hopefully this PR is not outside of the scope of the project. I would really appreciate some help, if possible. If I'm coming about this the wrong way, just let me know and I'll delete the pull request.

Recently, toying with my raspberry, I downloaded an image from [Ubuntu pi flavour maker](https://ubuntu-pi-flavour-maker.org/download/). Specifically the [raspberry 3](http://www.finnie.org/software/raspberrypi/ubuntu-rpi3/ubuntu-16.04-preinstalled-server-armhf+raspi3.img.xz) one. The file comes in as `.img.xz` which is a `Raw disk image (xz compressed)`. The mime type is defined at `/usr/share/mime/application/x-raw-disk-image-xz-compressed.xml`.

Using the Papirus icons, the icon it shows as is the default text icon, which I believe is the fall back. I've created the symlinks, as shown in this PR, but it doesn't seem to work. The icon shown continues to be the text one, and in my mime type editor it just shows as if there simply is no icon.

Have I named the symlink or the mime type wrongly?