### PR TITLE
fix situation, when THEMES is set, but empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@
 
 PREFIX ?= /usr
 IGNORE ?=
-THEMES ?= ePapirus Papirus Papirus-Adapta Papirus-Adapta-Nokto Papirus-Dark Papirus-Light
+
+ifeq ($(strip $(THEMES)),)
+	THEMES ?= ePapirus Papirus Papirus-Adapta Papirus-Adapta-Nokto Papirus-Dark Papirus-Light
+endif
 
 # excludes IGNORE from THEMES list
 THEMES := $(filter-out $(IGNORE), $(THEMES))


### PR DESCRIPTION
With ?=, if you run THEMES= make install, empty value is treated as specified and still replaced, making wrong arguments.

For now i catched this situation in calculate-linux, where calculate-utils has global THEMES variable, used to set unified theming in some packages, that support it, with assistanse of calculate-utils.
Using /etc/portage/env, it is possible only to set value, while unset is unsupported.