### PR TITLE
Add symbolic links for pycharm-professional

### DIFF
--- a/Papirus/16x16/apps/pycharm-professional.svg
+++ b/Papirus/16x16/apps/pycharm-professional.svg
@@ -1,0 +1,1 @@
+16x16/apps/pycharm.svg

--- a/Papirus/22x22/apps/pycharm-professional.svg
+++ b/Papirus/22x22/apps/pycharm-professional.svg
@@ -1,0 +1,1 @@
+22x22/apps/pycharm.svg

--- a/Papirus/24x24/apps/pycharm-professional.svg
+++ b/Papirus/24x24/apps/pycharm-professional.svg
@@ -1,0 +1,1 @@
+24x24/apps/pycharm.svg

--- a/Papirus/32x32/apps/pycharm-professional.svg
+++ b/Papirus/32x32/apps/pycharm-professional.svg
@@ -1,0 +1,1 @@
+32x32/apps/pycharm.svg

--- a/Papirus/48x48/apps/pycharm-professional.svg
+++ b/Papirus/48x48/apps/pycharm-professional.svg
@@ -1,0 +1,1 @@
+48x48/apps/pycharm.svg

--- a/Papirus/64x64/apps/pycharm-professional.svg
+++ b/Papirus/64x64/apps/pycharm-professional.svg
@@ -1,0 +1,1 @@
+64x64/apps/pycharm.svg


### PR DESCRIPTION
This is a fix for the version from Jonas Gröger's PPA https://github.com/JonasGroeger/jetbrains-ppa

