### PR TITLE
Add minecraft-launcher symlink

### DIFF
--- a/Papirus/16x16/apps/minecraft-launcher.svg
+++ b/Papirus/16x16/apps/minecraft-launcher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/22x22/apps/minecraft-launcher.svg
+++ b/Papirus/22x22/apps/minecraft-launcher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/24x24/apps/minecraft-launcher.svg
+++ b/Papirus/24x24/apps/minecraft-launcher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/32x32/apps/minecraft-launcher.svg
+++ b/Papirus/32x32/apps/minecraft-launcher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/48x48/apps/minecraft-launcher.svg
+++ b/Papirus/48x48/apps/minecraft-launcher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/64x64/apps/minecraft-launcher.svg
+++ b/Papirus/64x64/apps/minecraft-launcher.svg
@@ -1,0 +1,1 @@
+minecraft.svg


### PR DESCRIPTION
This icon is used by the new Minecraft launcher. (https://www.reddit.com/r/Minecraft/comments/5opl31/help_us_test_the_new_minecraft_launcher_now_with/)