### PR TITLE
Add symlinks for missing mimetypes & audio-handset

### DIFF
--- a/Papirus/16x16/devices/audio-headset.svg
+++ b/Papirus/16x16/devices/audio-headset.svg
@@ -1,0 +1,1 @@
+audio-headphones.svg

--- a/Papirus/16x16/mimetypes/text-rust.svg
+++ b/Papirus/16x16/mimetypes/text-rust.svg
@@ -1,0 +1,1 @@
+text-x-rust.svg

--- a/Papirus/16x16/mimetypes/video-mp2t.svg
+++ b/Papirus/16x16/mimetypes/video-mp2t.svg
@@ -1,0 +1,1 @@
+video-x-generic.svg

--- a/Papirus/22x22/devices/audio-headset.svg
+++ b/Papirus/22x22/devices/audio-headset.svg
@@ -1,0 +1,1 @@
+audio-headphones.svg

--- a/Papirus/22x22/mimetypes/text-rust.svg
+++ b/Papirus/22x22/mimetypes/text-rust.svg
@@ -1,0 +1,1 @@
+text-x-rust.svg

--- a/Papirus/22x22/mimetypes/video-mp2t.svg
+++ b/Papirus/22x22/mimetypes/video-mp2t.svg
@@ -1,0 +1,1 @@
+video-x-generic.svg

--- a/Papirus/24x24/devices/audio-headset.svg
+++ b/Papirus/24x24/devices/audio-headset.svg
@@ -1,0 +1,1 @@
+audio-headphones.svg

--- a/Papirus/24x24/mimetypes/text-rust.svg
+++ b/Papirus/24x24/mimetypes/text-rust.svg
@@ -1,0 +1,1 @@
+text-x-rust.svg

--- a/Papirus/24x24/mimetypes/video-mp2t.svg
+++ b/Papirus/24x24/mimetypes/video-mp2t.svg
@@ -1,0 +1,1 @@
+video-x-generic.svg

--- a/Papirus/32x32/devices/audio-headset.svg
+++ b/Papirus/32x32/devices/audio-headset.svg
@@ -1,0 +1,1 @@
+audio-headphones.svg

--- a/Papirus/32x32/mimetypes/text-rust.svg
+++ b/Papirus/32x32/mimetypes/text-rust.svg
@@ -1,0 +1,1 @@
+text-x-rust.svg

--- a/Papirus/32x32/mimetypes/video-mp2t.svg
+++ b/Papirus/32x32/mimetypes/video-mp2t.svg
@@ -1,0 +1,1 @@
+video-x-generic.svg

--- a/Papirus/48x48/devices/audio-headset.svg
+++ b/Papirus/48x48/devices/audio-headset.svg
@@ -1,0 +1,1 @@
+audio-headphones.svg

--- a/Papirus/48x48/mimetypes/text-rust.svg
+++ b/Papirus/48x48/mimetypes/text-rust.svg
@@ -1,0 +1,1 @@
+text-x-rust.svg

--- a/Papirus/48x48/mimetypes/video-mp2t.svg
+++ b/Papirus/48x48/mimetypes/video-mp2t.svg
@@ -1,0 +1,1 @@
+video-x-generic.svg

--- a/Papirus/64x64/devices/audio-headset.svg
+++ b/Papirus/64x64/devices/audio-headset.svg
@@ -1,0 +1,1 @@
+audio-headphones.svg

--- a/Papirus/64x64/mimetypes/text-rust.svg
+++ b/Papirus/64x64/mimetypes/text-rust.svg
@@ -1,0 +1,1 @@
+text-x-rust.svg

--- a/Papirus/64x64/mimetypes/video-mp2t.svg
+++ b/Papirus/64x64/mimetypes/video-mp2t.svg
@@ -1,0 +1,1 @@
+video-x-generic.svg


### PR DESCRIPTION
**Changes:**

* Add mimetype icon `text-rust.svg` (symlink to `text-x-rust.svg`). 
The Rust files (.rs) don't show the respective icon, since, according to shared-mime-info, the Rust mimetype is `text/rust` (the prefix `x-` is deprecated).
	* Freedesktop. Add text/rust for Rust source code: https://bugs.freedesktop.org/show_bug.cgi?id=90487
	* shared-mime-info: https://freedesktop.org/wiki/Software/shared-mime-info/
	* Deprecating the "X-" Prefix: https://tools.ietf.org/html/rfc6648

* Add mimetype icon for MP2T videos: `video-mp2t.svg` (symlink to `video-x-generic.svg`).
	* MPEG-2 TS Byte Stream Format, MIME-type info: https://www.w3.org/2013/12/byte-stream-format-registry/mp2t-byte-stream-format.html#mime-parameters

* Add missing audio-headset icon in devices folder: `audio-headset.svg` (symlink to `audio-headphones.svg`). For example, when connecting headset via bluetooth, the `breeze` or `gnome` icon of headset is displayed.

Any inconvenience or if I need to change something, don't hesitate to notify!