### PR TITLE
Add symlinks for some Linux Mint apps

### DIFF
--- a/Papirus/16x16/apps/mintlocale-im.svg
+++ b/Papirus/16x16/apps/mintlocale-im.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard-shortcuts.svg

--- a/Papirus/16x16/apps/mintsources-mint.svg
+++ b/Papirus/16x16/apps/mintsources-mint.svg
@@ -1,0 +1,1 @@
+distributor-logo-linux-mint.svg

--- a/Papirus/16x16/apps/mintstick.svg
+++ b/Papirus/16x16/apps/mintstick.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/16x16/apps/mintupdate-release-upgrade.svg
+++ b/Papirus/16x16/apps/mintupdate-release-upgrade.svg
@@ -1,0 +1,1 @@
+muon.svg

--- a/Papirus/22x22/apps/mintlocale-im.svg
+++ b/Papirus/22x22/apps/mintlocale-im.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard-shortcuts.svg

--- a/Papirus/22x22/apps/mintsources-mint.svg
+++ b/Papirus/22x22/apps/mintsources-mint.svg
@@ -1,0 +1,1 @@
+distributor-logo-linux-mint.svg

--- a/Papirus/22x22/apps/mintstick.svg
+++ b/Papirus/22x22/apps/mintstick.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/22x22/apps/mintupdate-release-upgrade.svg
+++ b/Papirus/22x22/apps/mintupdate-release-upgrade.svg
@@ -1,0 +1,1 @@
+muon.svg

--- a/Papirus/24x24/apps/mintlocale-im.svg
+++ b/Papirus/24x24/apps/mintlocale-im.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard-shortcuts.svg

--- a/Papirus/24x24/apps/mintsources-mint.svg
+++ b/Papirus/24x24/apps/mintsources-mint.svg
@@ -1,0 +1,1 @@
+distributor-logo-linux-mint.svg

--- a/Papirus/24x24/apps/mintstick.svg
+++ b/Papirus/24x24/apps/mintstick.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/24x24/apps/mintupdate-release-upgrade.svg
+++ b/Papirus/24x24/apps/mintupdate-release-upgrade.svg
@@ -1,0 +1,1 @@
+muon.svg

--- a/Papirus/32x32/apps/mintlocale-im.svg
+++ b/Papirus/32x32/apps/mintlocale-im.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard-shortcuts.svg

--- a/Papirus/32x32/apps/mintsources-mint.svg
+++ b/Papirus/32x32/apps/mintsources-mint.svg
@@ -1,0 +1,1 @@
+distributor-logo-linux-mint.svg

--- a/Papirus/32x32/apps/mintstick.svg
+++ b/Papirus/32x32/apps/mintstick.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/32x32/apps/mintupdate-release-upgrade.svg
+++ b/Papirus/32x32/apps/mintupdate-release-upgrade.svg
@@ -1,0 +1,1 @@
+muon.svg

--- a/Papirus/48x48/apps/mintlocale-im.svg
+++ b/Papirus/48x48/apps/mintlocale-im.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard-shortcuts.svg

--- a/Papirus/48x48/apps/mintsources-mint.svg
+++ b/Papirus/48x48/apps/mintsources-mint.svg
@@ -1,0 +1,1 @@
+distributor-logo-linux-mint.svg

--- a/Papirus/48x48/apps/mintstick.svg
+++ b/Papirus/48x48/apps/mintstick.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/48x48/apps/mintupdate-release-upgrade.svg
+++ b/Papirus/48x48/apps/mintupdate-release-upgrade.svg
@@ -1,0 +1,1 @@
+muon.svg

--- a/Papirus/64x64/apps/mintlocale-im.svg
+++ b/Papirus/64x64/apps/mintlocale-im.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard-shortcuts.svg

--- a/Papirus/64x64/apps/mintsources-mint.svg
+++ b/Papirus/64x64/apps/mintsources-mint.svg
@@ -1,0 +1,1 @@
+distributor-logo-linux-mint.svg

--- a/Papirus/64x64/apps/mintstick.svg
+++ b/Papirus/64x64/apps/mintstick.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/64x64/apps/mintupdate-release-upgrade.svg
+++ b/Papirus/64x64/apps/mintupdate-release-upgrade.svg
@@ -1,0 +1,1 @@
+muon.svg


### PR DESCRIPTION
```
mintlocale-im.svg -> preferences-desktop-keyboard-shortcuts.svg
mintstick.svg -> usb-creator.svg
mintupdate-release-upgrade.svg -> muon.svg
mintsources-mint.svg -> distributor-logo-linux-mint.svg
```

`mintsources-mint.svg` is a part of #1337 . But other icons in that issue cannot be fixed with symlinks.