### PR TITLE
Add symlinks for Wesnoth

### DIFF
--- a/Papirus/16x16/apps/steam_icon_599390.svg
+++ b/Papirus/16x16/apps/steam_icon_599390.svg
@@ -1,0 +1,1 @@
+wesnoth.svg

--- a/Papirus/22x22/apps/steam_icon_599390.svg
+++ b/Papirus/22x22/apps/steam_icon_599390.svg
@@ -1,0 +1,1 @@
+wesnoth.svg

--- a/Papirus/24x24/apps/steam_icon_599390.svg
+++ b/Papirus/24x24/apps/steam_icon_599390.svg
@@ -1,0 +1,1 @@
+wesnoth.svg

--- a/Papirus/32x32/apps/steam_icon_599390.svg
+++ b/Papirus/32x32/apps/steam_icon_599390.svg
@@ -1,0 +1,1 @@
+wesnoth.svg

--- a/Papirus/48x48/apps/steam_icon_599390.svg
+++ b/Papirus/48x48/apps/steam_icon_599390.svg
@@ -1,0 +1,1 @@
+wesnoth.svg

--- a/Papirus/64x64/apps/steam_icon_599390.svg
+++ b/Papirus/64x64/apps/steam_icon_599390.svg
@@ -1,0 +1,1 @@
+wesnoth.svg


### PR DESCRIPTION
Now [the Battle for Wesnoth](https://wesnoth.org/) is available on [Steam](https://store.steampowered.com/app/599390/Battle_for_Wesnoth/).