### PR TITLE
Added various missing icons for YaST

### DIFF
--- a/Papirus/16x16/apps/yast-device-tree.svg
+++ b/Papirus/16x16/apps/yast-device-tree.svg
@@ -1,0 +1,1 @@
+preferences-system-network.svg

--- a/Papirus/16x16/apps/yast-kerberos.svg
+++ b/Papirus/16x16/apps/yast-kerberos.svg
@@ -1,0 +1,1 @@
+preferences-desktop-user-password.svg

--- a/Papirus/16x16/apps/yast-ldap-server.svg
+++ b/Papirus/16x16/apps/yast-ldap-server.svg
@@ -1,0 +1,1 @@
+krfb.svg

--- a/Papirus/16x16/apps/yast-tftp-server.svg
+++ b/Papirus/16x16/apps/yast-tftp-server.svg
@@ -1,0 +1,1 @@
+bareftp.svg

--- a/Papirus/16x16/apps/yast-x11.svg
+++ b/Papirus/16x16/apps/yast-x11.svg
@@ -1,0 +1,1 @@
+fonts.svg

--- a/Papirus/22x22/apps/yast-device-tree.svg
+++ b/Papirus/22x22/apps/yast-device-tree.svg
@@ -1,0 +1,1 @@
+preferences-system-network.svg

--- a/Papirus/22x22/apps/yast-kerberos.svg
+++ b/Papirus/22x22/apps/yast-kerberos.svg
@@ -1,0 +1,1 @@
+preferences-desktop-user-password.svg

--- a/Papirus/22x22/apps/yast-ldap-server.svg
+++ b/Papirus/22x22/apps/yast-ldap-server.svg
@@ -1,0 +1,1 @@
+krfb.svg

--- a/Papirus/22x22/apps/yast-tftp-server.svg
+++ b/Papirus/22x22/apps/yast-tftp-server.svg
@@ -1,0 +1,1 @@
+bareftp.svg

--- a/Papirus/22x22/apps/yast-x11.svg
+++ b/Papirus/22x22/apps/yast-x11.svg
@@ -1,0 +1,1 @@
+fonts.svg

--- a/Papirus/24x24/apps/yast-device-tree.svg
+++ b/Papirus/24x24/apps/yast-device-tree.svg
@@ -1,0 +1,1 @@
+preferences-system-network.svg

--- a/Papirus/24x24/apps/yast-kerberos.svg
+++ b/Papirus/24x24/apps/yast-kerberos.svg
@@ -1,0 +1,1 @@
+preferences-desktop-user-password.svg

--- a/Papirus/24x24/apps/yast-ldap-server.svg
+++ b/Papirus/24x24/apps/yast-ldap-server.svg
@@ -1,0 +1,1 @@
+krfb.svg

--- a/Papirus/24x24/apps/yast-tftp-server.svg
+++ b/Papirus/24x24/apps/yast-tftp-server.svg
@@ -1,0 +1,1 @@
+bareftp.svg

--- a/Papirus/24x24/apps/yast-x11.svg
+++ b/Papirus/24x24/apps/yast-x11.svg
@@ -1,0 +1,1 @@
+fonts.svg

--- a/Papirus/32x32/apps/yast-device-tree.svg
+++ b/Papirus/32x32/apps/yast-device-tree.svg
@@ -1,0 +1,1 @@
+preferences-system-network.svg

--- a/Papirus/32x32/apps/yast-kerberos.svg
+++ b/Papirus/32x32/apps/yast-kerberos.svg
@@ -1,0 +1,1 @@
+preferences-desktop-user-password.svg

--- a/Papirus/32x32/apps/yast-ldap-server.svg
+++ b/Papirus/32x32/apps/yast-ldap-server.svg
@@ -1,0 +1,1 @@
+krfb.svg

--- a/Papirus/32x32/apps/yast-tftp-server.svg
+++ b/Papirus/32x32/apps/yast-tftp-server.svg
@@ -1,0 +1,1 @@
+bareftp.svg

--- a/Papirus/32x32/apps/yast-x11.svg
+++ b/Papirus/32x32/apps/yast-x11.svg
@@ -1,0 +1,1 @@
+fonts.svg

--- a/Papirus/48x48/apps/yast-device-tree.svg
+++ b/Papirus/48x48/apps/yast-device-tree.svg
@@ -1,0 +1,1 @@
+preferences-system-network.svg

--- a/Papirus/48x48/apps/yast-kerberos.svg
+++ b/Papirus/48x48/apps/yast-kerberos.svg
@@ -1,0 +1,1 @@
+preferences-desktop-user-password.svg

--- a/Papirus/48x48/apps/yast-ldap-server.svg
+++ b/Papirus/48x48/apps/yast-ldap-server.svg
@@ -1,0 +1,1 @@
+krfb.svg

--- a/Papirus/48x48/apps/yast-tftp-server.svg
+++ b/Papirus/48x48/apps/yast-tftp-server.svg
@@ -1,0 +1,1 @@
+bareftp.svg

--- a/Papirus/48x48/apps/yast-x11.svg
+++ b/Papirus/48x48/apps/yast-x11.svg
@@ -1,0 +1,1 @@
+fonts.svg

--- a/Papirus/64x64/apps/yast-device-tree.svg
+++ b/Papirus/64x64/apps/yast-device-tree.svg
@@ -1,0 +1,1 @@
+preferences-system-network.svg

--- a/Papirus/64x64/apps/yast-kerberos.svg
+++ b/Papirus/64x64/apps/yast-kerberos.svg
@@ -1,0 +1,1 @@
+preferences-desktop-user-password.svg

--- a/Papirus/64x64/apps/yast-ldap-server.svg
+++ b/Papirus/64x64/apps/yast-ldap-server.svg
@@ -1,0 +1,1 @@
+krfb.svg

--- a/Papirus/64x64/apps/yast-tftp-server.svg
+++ b/Papirus/64x64/apps/yast-tftp-server.svg
@@ -1,0 +1,1 @@
+bareftp.svg

--- a/Papirus/64x64/apps/yast-x11.svg
+++ b/Papirus/64x64/apps/yast-x11.svg
@@ -1,0 +1,1 @@
+fonts.svg


### PR DESCRIPTION
Adds symlinks to various icons. This is due to YaST having a few items included by default that are, as of now, unthemed by Papirus. This commit adds these missing icons.