### PR TITLE
add symlinks for sublime-text2/3

### DIFF
--- a/Papirus/16x16/apps/sublime-text2.svg
+++ b/Papirus/16x16/apps/sublime-text2.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/16x16/apps/sublime-text3.svg
+++ b/Papirus/16x16/apps/sublime-text3.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/22x22/apps/sublime-text2.svg
+++ b/Papirus/22x22/apps/sublime-text2.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/22x22/apps/sublime-text3.svg
+++ b/Papirus/22x22/apps/sublime-text3.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/24x24/apps/sublime-text2.svg
+++ b/Papirus/24x24/apps/sublime-text2.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/24x24/apps/sublime-text3.svg
+++ b/Papirus/24x24/apps/sublime-text3.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/32x32/apps/sublime-text2.svg
+++ b/Papirus/32x32/apps/sublime-text2.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/32x32/apps/sublime-text3.svg
+++ b/Papirus/32x32/apps/sublime-text3.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/48x48/apps/sublime-text2.svg
+++ b/Papirus/48x48/apps/sublime-text2.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/48x48/apps/sublime-text3.svg
+++ b/Papirus/48x48/apps/sublime-text3.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/64x64/apps/sublime-text2.svg
+++ b/Papirus/64x64/apps/sublime-text2.svg
@@ -1,0 +1,1 @@
+sublime-text.svg

--- a/Papirus/64x64/apps/sublime-text3.svg
+++ b/Papirus/64x64/apps/sublime-text3.svg
@@ -1,0 +1,1 @@
+sublime-text.svg


### PR DESCRIPTION
The icon name of sublime2 package is sublime-text2, in the archlinuxcn community repository.