### PR TITLE
Added symlinks for Unreal editor binaries

### DIFF
--- a/Papirus/16x16/apps/ubinary.svg
+++ b/Papirus/16x16/apps/ubinary.svg
@@ -1,0 +1,1 @@
+ue4editor.svg

--- a/Papirus/22x22/apps/ubinary.svg
+++ b/Papirus/22x22/apps/ubinary.svg
@@ -1,0 +1,1 @@
+ue4editor.svg

--- a/Papirus/24x24/apps/ubinary.svg
+++ b/Papirus/24x24/apps/ubinary.svg
@@ -1,0 +1,1 @@
+ue4editor.svg

--- a/Papirus/32x32/apps/ubinary.svg
+++ b/Papirus/32x32/apps/ubinary.svg
@@ -1,0 +1,1 @@
+ue4editor.svg

--- a/Papirus/48x48/apps/ubinary.svg
+++ b/Papirus/48x48/apps/ubinary.svg
@@ -1,0 +1,1 @@
+ue4editor.svg

--- a/Papirus/64x64/apps/ubinary.svg
+++ b/Papirus/64x64/apps/ubinary.svg
@@ -1,0 +1,1 @@
+ue4editor.svg


### PR DESCRIPTION
The Unreal Editor application produced by building from the git source uses the icon name 'ubinary', for compatibility, symlinking the ue4editor icon to the ubinary icon is ideal. 