### PR TITLE
Shorten install command for Solus

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Packages in this section are not part of the official repositories. If you have 
 | openSUSE      | Konstantin Voinov  | [papirus-icon-theme](https://software.opensuse.org/download.html?project=home:kill_it&package=papirus-icon-theme) <sup>OBS [[link](https://build.opensuse.org/package/show/home:kill_it/papirus-icon-theme)]</sub> |
 | openSUSE      | Matthias Eliasson  | [papirus-icon-theme](https://software.opensuse.org/package/papirus-icon-theme) <sup>official</sup> |
 | ROSA Linux    | Vladimir Penchikov | `sudo urpmi papirus-icon-theme` |
-| Solus         | Joshua Strobl      | `sudo eopkg install papirus-icon-theme` |
+| Solus         | Joshua Strobl      | `sudo eopkg it papirus-icon-theme` |
 | Ubuntu 18.04+ | Yangfl             | `sudo apt install papirus-icon-theme` |  
 | Void Linux | Giuseppe Fierro             | `sudo xbps-install papirus-icon-theme` |
 


### PR DESCRIPTION
Use `it` instead of `install` so users don't need to type as much...