### PR TITLE
Add shadow-dev icon symlink for Ubuntu/Debian packages

### DIFF
--- a/Papirus/16x16/apps/shadow-dev.svg
+++ b/Papirus/16x16/apps/shadow-dev.svg
@@ -1,0 +1,1 @@
+shadow-preprod.svg

--- a/Papirus/22x22/apps/shadow-dev.svg
+++ b/Papirus/22x22/apps/shadow-dev.svg
@@ -1,0 +1,1 @@
+shadow-preprod.svg

--- a/Papirus/24x24/apps/shadow-dev.svg
+++ b/Papirus/24x24/apps/shadow-dev.svg
@@ -1,0 +1,1 @@
+shadow-preprod.svg

--- a/Papirus/32x32/apps/shadow-dev.svg
+++ b/Papirus/32x32/apps/shadow-dev.svg
@@ -1,0 +1,1 @@
+shadow-preprod.svg

--- a/Papirus/48x48/apps/shadow-dev.svg
+++ b/Papirus/48x48/apps/shadow-dev.svg
@@ -1,0 +1,1 @@
+shadow-preprod.svg

--- a/Papirus/64x64/apps/shadow-dev.svg
+++ b/Papirus/64x64/apps/shadow-dev.svg
@@ -1,0 +1,1 @@
+shadow-preprod.svg


### PR DESCRIPTION
In the Debian package found in https://shadow.tech/linux/shadow-beta.zip the icon is shadow-dev. In order to make this icon work on these distros as well, a symlink is needed.