### PR TITLE
Link skanlite -> org.gnome.SimpleScan.svg for Simple Scan

### DIFF
--- a/Papirus/16x16/apps/org.gnome.SimpleScan.svg
+++ b/Papirus/16x16/apps/org.gnome.SimpleScan.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/22x22/apps/org.gnome.SimpleScan.svg
+++ b/Papirus/22x22/apps/org.gnome.SimpleScan.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/24x24/apps/org.gnome.SimpleScan.svg
+++ b/Papirus/24x24/apps/org.gnome.SimpleScan.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/32x32/apps/org.gnome.SimpleScan.svg
+++ b/Papirus/32x32/apps/org.gnome.SimpleScan.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/48x48/apps/org.gnome.SimpleScan.svg
+++ b/Papirus/48x48/apps/org.gnome.SimpleScan.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/64x64/apps/org.gnome.SimpleScan.svg
+++ b/Papirus/64x64/apps/org.gnome.SimpleScan.svg
@@ -1,0 +1,1 @@
+skanlite.svg


### PR DESCRIPTION
[dylan@dylantaylor-precision papirus-icon-theme]$ cat /usr/share/applications/simple-scan.desktop  | grep Icon
Icon=org.gnome.SimpleScan

I put the grep in because the output is really long