### PR TITLE
Add new symlink for GHex

### DIFF
--- a/Papirus/16x16/apps/org.gnome.GHex.svg
+++ b/Papirus/16x16/apps/org.gnome.GHex.svg
@@ -1,0 +1,1 @@
+ghex.svg

--- a/Papirus/22x22/apps/org.gnome.GHex.svg
+++ b/Papirus/22x22/apps/org.gnome.GHex.svg
@@ -1,0 +1,1 @@
+ghex.svg

--- a/Papirus/24x24/apps/org.gnome.GHex.svg
+++ b/Papirus/24x24/apps/org.gnome.GHex.svg
@@ -1,0 +1,1 @@
+ghex.svg

--- a/Papirus/32x32/apps/org.gnome.GHex.svg
+++ b/Papirus/32x32/apps/org.gnome.GHex.svg
@@ -1,0 +1,1 @@
+ghex.svg

--- a/Papirus/48x48/apps/org.gnome.GHex.svg
+++ b/Papirus/48x48/apps/org.gnome.GHex.svg
@@ -1,0 +1,1 @@
+ghex.svg

--- a/Papirus/64x64/apps/org.gnome.GHex.svg
+++ b/Papirus/64x64/apps/org.gnome.GHex.svg
@@ -1,0 +1,1 @@
+ghex.svg


### PR DESCRIPTION
The icon name changed in version 3.18.4.