### PR TITLE
fixed: protonmail-desktop-unnofficial having the wrong icon

### DIFF
--- a/Papirus/16x16/apps/protonmail-desktop-unofficial.svg
+++ b/Papirus/16x16/apps/protonmail-desktop-unofficial.svg
@@ -1,0 +1,1 @@
+/home/tom/Git/papirus-icon-theme/Papirus/16x16/apps/protonmail-desktop.svg

--- a/Papirus/22x22/apps/protonmail-desktop-unofficial.svg
+++ b/Papirus/22x22/apps/protonmail-desktop-unofficial.svg
@@ -1,0 +1,1 @@
+/home/tom/Git/papirus-icon-theme/Papirus/22x22/apps/protonmail-desktop.svg

--- a/Papirus/24x24/apps/protonmail-desktop-unofficial.svg
+++ b/Papirus/24x24/apps/protonmail-desktop-unofficial.svg
@@ -1,0 +1,1 @@
+/home/tom/Git/papirus-icon-theme/Papirus/24x24/apps/protonmail-desktop.svg

--- a/Papirus/32x32/apps/protonmail-desktop-unofficial.svg
+++ b/Papirus/32x32/apps/protonmail-desktop-unofficial.svg
@@ -1,0 +1,1 @@
+/home/tom/Git/papirus-icon-theme/Papirus/32x32/apps/protonmail-desktop.svg

--- a/Papirus/48x48/apps/protonmail-desktop-unofficial.svg
+++ b/Papirus/48x48/apps/protonmail-desktop-unofficial.svg
@@ -1,0 +1,1 @@
+/home/tom/Git/papirus-icon-theme/Papirus/48x48/apps/protonmail-desktop.svg

--- a/Papirus/64x64/apps/protonmail-desktop-unofficial.svg
+++ b/Papirus/64x64/apps/protonmail-desktop-unofficial.svg
@@ -1,0 +1,1 @@
+/home/tom/Git/papirus-icon-theme/Papirus/64x64/apps/protonmail-desktop.svg


### PR DESCRIPTION
The `protonmail-desktop-unofficial` client didn't have the correct icon for me.
In the .desktop file under `/usr/share/applications/` created by the rpm installer it used `protonmail-desktop-unofficial` as the icon. I just created symlinks to the already existing icons.
The pull request is just in case this needs to be fixed by the papirus team and not by the packager of `protonmail-desktop-unofficial`.

I am using this application: https://github.com/protonmail-desktop/application on fedora 30