### PR TITLE
Added symlink 'apps/chromium-browser.svg' -> 'apps/chromium-browser-privacy.svg'

### DIFF
--- a/Papirus/16x16/apps/chromium-browser-privacy.svg
+++ b/Papirus/16x16/apps/chromium-browser-privacy.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/22x22/apps/chromium-browser-privacy.svg
+++ b/Papirus/22x22/apps/chromium-browser-privacy.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/24x24/apps/chromium-browser-privacy.svg
+++ b/Papirus/24x24/apps/chromium-browser-privacy.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/32x32/apps/chromium-browser-privacy.svg
+++ b/Papirus/32x32/apps/chromium-browser-privacy.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/48x48/apps/chromium-browser-privacy.svg
+++ b/Papirus/48x48/apps/chromium-browser-privacy.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/64x64/apps/chromium-browser-privacy.svg
+++ b/Papirus/64x64/apps/chromium-browser-privacy.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg


### PR DESCRIPTION
The `chromium-browser-privacy` package (ungoogled-chromium) for Fedora 31 uses a different icon-name for the browser.