### PR TITLE
symlink figma figma-linux

### DIFF
--- a/Papirus/16x16/apps/figma-linux.svg
+++ b/Papirus/16x16/apps/figma-linux.svg
@@ -1,0 +1,1 @@
+figma.svg

--- a/Papirus/22x22/apps/figma-linux.svg
+++ b/Papirus/22x22/apps/figma-linux.svg
@@ -1,0 +1,1 @@
+figma.svg

--- a/Papirus/24x24/apps/figma-linux.svg
+++ b/Papirus/24x24/apps/figma-linux.svg
@@ -1,0 +1,1 @@
+figma.svg

--- a/Papirus/32x32/apps/figma-linux.svg
+++ b/Papirus/32x32/apps/figma-linux.svg
@@ -1,0 +1,1 @@
+figma.svg

--- a/Papirus/48x48/apps/figma-linux.svg
+++ b/Papirus/48x48/apps/figma-linux.svg
@@ -1,0 +1,1 @@
+figma.svg

--- a/Papirus/64x64/apps/figma-linux.svg
+++ b/Papirus/64x64/apps/figma-linux.svg
@@ -1,0 +1,1 @@
+figma.svg


### PR DESCRIPTION
The latest debian package of [figma-linux](https://github.com/Figma-Linux/figma-linux) has `figma-linux` set as the icon name.