### PR TITLE
Symlink Ardour 6

### DIFF
--- a/Papirus/16x16/apps/ardour6.svg
+++ b/Papirus/16x16/apps/ardour6.svg
@@ -1,0 +1,1 @@
+ardour.svg

--- a/Papirus/22x22/apps/ardour6.svg
+++ b/Papirus/22x22/apps/ardour6.svg
@@ -1,0 +1,1 @@
+ardour.svg

--- a/Papirus/24x24/apps/ardour6.svg
+++ b/Papirus/24x24/apps/ardour6.svg
@@ -1,0 +1,1 @@
+ardour.svg

--- a/Papirus/32x32/apps/ardour6.svg
+++ b/Papirus/32x32/apps/ardour6.svg
@@ -1,0 +1,1 @@
+ardour.svg

--- a/Papirus/48x48/apps/ardour6.svg
+++ b/Papirus/48x48/apps/ardour6.svg
@@ -1,0 +1,1 @@
+ardour.svg

--- a/Papirus/64x64/apps/ardour6.svg
+++ b/Papirus/64x64/apps/ardour6.svg
@@ -1,0 +1,1 @@
+ardour.svg


### PR DESCRIPTION
Don't know, why Ardour versions its icon name, but they do, so this fixes the Ardour icon again.