### PR TITLE
Add symlinks for new Nicotine+ icon name

### DIFF
--- a/Papirus/16x16/apps/org.nicotine_plus.Nicotine.svg
+++ b/Papirus/16x16/apps/org.nicotine_plus.Nicotine.svg
@@ -1,0 +1,1 @@
+nicotine-plus.svg

--- a/Papirus/22x22/apps/org.nicotine_plus.Nicotine.svg
+++ b/Papirus/22x22/apps/org.nicotine_plus.Nicotine.svg
@@ -1,0 +1,1 @@
+nicotine-plus.svg

--- a/Papirus/24x24/apps/org.nicotine_plus.Nicotine.svg
+++ b/Papirus/24x24/apps/org.nicotine_plus.Nicotine.svg
@@ -1,0 +1,1 @@
+nicotine-plus.svg

--- a/Papirus/32x32/apps/org.nicotine_plus.Nicotine.svg
+++ b/Papirus/32x32/apps/org.nicotine_plus.Nicotine.svg
@@ -1,0 +1,1 @@
+nicotine-plus.svg

--- a/Papirus/48x48/apps/org.nicotine_plus.Nicotine.svg
+++ b/Papirus/48x48/apps/org.nicotine_plus.Nicotine.svg
@@ -1,0 +1,1 @@
+nicotine-plus.svg

--- a/Papirus/64x64/apps/org.nicotine_plus.Nicotine.svg
+++ b/Papirus/64x64/apps/org.nicotine_plus.Nicotine.svg
@@ -1,0 +1,1 @@
+nicotine-plus.svg


### PR DESCRIPTION
We changed the icon name upstream to follow RDNN.