### PR TITLE
Add symlinks for xfce4-session (Switch User)

### DIFF
--- a/Papirus/16x16/apps/xfsm-switch-user.svg
+++ b/Papirus/16x16/apps/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+system-switch-user.svg

--- a/Papirus/22x22/apps/xfsm-switch-user.svg
+++ b/Papirus/22x22/apps/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+system-switch-user.svg

--- a/Papirus/24x24/apps/xfsm-switch-user.svg
+++ b/Papirus/24x24/apps/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+system-switch-user.svg

--- a/Papirus/32x32/apps/xfsm-switch-user.svg
+++ b/Papirus/32x32/apps/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+system-switch-user.svg

--- a/Papirus/48x48/apps/xfsm-switch-user.svg
+++ b/Papirus/48x48/apps/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+system-switch-user.svg

--- a/Papirus/64x64/apps/xfsm-switch-user.svg
+++ b/Papirus/64x64/apps/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+system-switch-user.svg


### PR DESCRIPTION
Hi,
In the upcoming Xfce 4.16, some icons were introduced to act as fallbacks for icon themes have bad/ugly/inconsistent fallbacks.
With xfce4-session, I noticed an inconsistency in the logout dialog, fortunately Papirus already provide symlinks for most of `xfsm-*` icons, except the newly introduced `xfsm-switch-user`. This pull request creates symlinks to `system-switch-user`, alternatively `system-users` can be used if it's desired to retain the previous look.

Xfce 4.14 | Xfce 4.15 | Xfce 4.15 + this PR
------------ | ------------- | -------------
![4 14](https://user-images.githubusercontent.com/599565/99020468-791b5800-253d-11eb-9b94-3d3d271e1931.png) | ![before](https://user-images.githubusercontent.com/599565/99020465-77ea2b00-253d-11eb-937a-f4c12e837085.png) | ![after](https://user-images.githubusercontent.com/599565/99020470-79b3ee80-253d-11eb-98c0-932f0369aaf8.png)