### PR TITLE
Symlink some icons

### DIFF
--- a/Papirus/16x16/apps/csgo_linux64.svg
+++ b/Papirus/16x16/apps/csgo_linux64.svg
@@ -1,0 +1,1 @@
+csgo.svg

--- a/Papirus/16x16/mimetypes/application-vnd.amazon.mobi8-ebook.svg
+++ b/Papirus/16x16/mimetypes/application-vnd.amazon.mobi8-ebook.svg
@@ -1,0 +1,1 @@
+application-x-fictionbook.svg

--- a/Papirus/16x16/mimetypes/application-x-bps-patch.svg
+++ b/Papirus/16x16/mimetypes/application-x-bps-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/16x16/mimetypes/application-x-compressed-iso.svg
+++ b/Papirus/16x16/mimetypes/application-x-compressed-iso.svg
@@ -1,0 +1,1 @@
+application-x-compress.svg

--- a/Papirus/16x16/mimetypes/application-x-ips-patch.svg
+++ b/Papirus/16x16/mimetypes/application-x-ips-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/22x22/apps/csgo_linux64.svg
+++ b/Papirus/22x22/apps/csgo_linux64.svg
@@ -1,0 +1,1 @@
+csgo.svg

--- a/Papirus/22x22/mimetypes/application-vnd.amazon.mobi8-ebook.svg
+++ b/Papirus/22x22/mimetypes/application-vnd.amazon.mobi8-ebook.svg
@@ -1,0 +1,1 @@
+application-x-fictionbook.svg

--- a/Papirus/22x22/mimetypes/application-x-bps-patch.svg
+++ b/Papirus/22x22/mimetypes/application-x-bps-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/22x22/mimetypes/application-x-compressed-iso.svg
+++ b/Papirus/22x22/mimetypes/application-x-compressed-iso.svg
@@ -1,0 +1,1 @@
+application-x-compress.svg

--- a/Papirus/22x22/mimetypes/application-x-ips-patch.svg
+++ b/Papirus/22x22/mimetypes/application-x-ips-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/24x24/apps/csgo_linux64.svg
+++ b/Papirus/24x24/apps/csgo_linux64.svg
@@ -1,0 +1,1 @@
+csgo.svg

--- a/Papirus/24x24/mimetypes/application-vnd.amazon.mobi8-ebook.svg
+++ b/Papirus/24x24/mimetypes/application-vnd.amazon.mobi8-ebook.svg
@@ -1,0 +1,1 @@
+application-x-fictionbook.svg

--- a/Papirus/24x24/mimetypes/application-x-bps-patch.svg
+++ b/Papirus/24x24/mimetypes/application-x-bps-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/24x24/mimetypes/application-x-compressed-iso.svg
+++ b/Papirus/24x24/mimetypes/application-x-compressed-iso.svg
@@ -1,0 +1,1 @@
+application-x-compress.svg

--- a/Papirus/24x24/mimetypes/application-x-ips-patch.svg
+++ b/Papirus/24x24/mimetypes/application-x-ips-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/32x32/apps/csgo_linux64.svg
+++ b/Papirus/32x32/apps/csgo_linux64.svg
@@ -1,0 +1,1 @@
+csgo.svg

--- a/Papirus/32x32/mimetypes/application-vnd.amazon.mobi8-ebook.svg
+++ b/Papirus/32x32/mimetypes/application-vnd.amazon.mobi8-ebook.svg
@@ -1,0 +1,1 @@
+application-x-fictionbook.svg

--- a/Papirus/32x32/mimetypes/application-x-bps-patch.svg
+++ b/Papirus/32x32/mimetypes/application-x-bps-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/32x32/mimetypes/application-x-compressed-iso.svg
+++ b/Papirus/32x32/mimetypes/application-x-compressed-iso.svg
@@ -1,0 +1,1 @@
+application-x-compress.svg

--- a/Papirus/32x32/mimetypes/application-x-ips-patch.svg
+++ b/Papirus/32x32/mimetypes/application-x-ips-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/48x48/apps/csgo_linux64.svg
+++ b/Papirus/48x48/apps/csgo_linux64.svg
@@ -1,0 +1,1 @@
+csgo.svg

--- a/Papirus/48x48/mimetypes/application-vnd.amazon.mobi8-ebook.svg
+++ b/Papirus/48x48/mimetypes/application-vnd.amazon.mobi8-ebook.svg
@@ -1,0 +1,1 @@
+application-x-fictionbook.svg

--- a/Papirus/48x48/mimetypes/application-x-bps-patch.svg
+++ b/Papirus/48x48/mimetypes/application-x-bps-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/48x48/mimetypes/application-x-compressed-iso.svg
+++ b/Papirus/48x48/mimetypes/application-x-compressed-iso.svg
@@ -1,0 +1,1 @@
+application-x-compress.svg

--- a/Papirus/48x48/mimetypes/application-x-ips-patch.svg
+++ b/Papirus/48x48/mimetypes/application-x-ips-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/64x64/apps/csgo_linux64.svg
+++ b/Papirus/64x64/apps/csgo_linux64.svg
@@ -1,0 +1,1 @@
+csgo.svg

--- a/Papirus/64x64/mimetypes/application-vnd.amazon.mobi8-ebook.svg
+++ b/Papirus/64x64/mimetypes/application-vnd.amazon.mobi8-ebook.svg
@@ -1,0 +1,1 @@
+application-x-fictionbook.svg

--- a/Papirus/64x64/mimetypes/application-x-bps-patch.svg
+++ b/Papirus/64x64/mimetypes/application-x-bps-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg

--- a/Papirus/64x64/mimetypes/application-x-compressed-iso.svg
+++ b/Papirus/64x64/mimetypes/application-x-compressed-iso.svg
@@ -1,0 +1,1 @@
+application-x-compress.svg

--- a/Papirus/64x64/mimetypes/application-x-ips-patch.svg
+++ b/Papirus/64x64/mimetypes/application-x-ips-patch.svg
@@ -1,0 +1,1 @@
+text-x-patch.svg


### PR DESCRIPTION
apps:
`csgo_linux64.svg` -> `csgo.svg` (used in PulseAudio applet)

mimetypes:
`application-vnd.amazon.mobi8-ebook.svg` -> `application-x-fictionbook.svg`
`application-x-bps-patch.svg` -> `text-x-patch.svg`
`application-x-compressed-iso.svg` -> `application-x-compress.svg`
`application-x-ips-patch.svg` -> `text-x-patch.svg`
