### PR TITLE
symlink application-octet-stream to unknown

### DIFF
--- a/Papirus/16x16/mimetypes/application-octet-stream.svg
+++ b/Papirus/16x16/mimetypes/application-octet-stream.svg
@@ -1,1 +1,1 @@
-application-x-zerosize.svg
+unknown.svg

--- a/Papirus/22x22/mimetypes/application-octet-stream.svg
+++ b/Papirus/22x22/mimetypes/application-octet-stream.svg
@@ -1,1 +1,1 @@
-application-x-zerosize.svg
+unknown.svg

--- a/Papirus/24x24/mimetypes/application-octet-stream.svg
+++ b/Papirus/24x24/mimetypes/application-octet-stream.svg
@@ -1,1 +1,1 @@
-application-x-zerosize.svg
+unknown.svg

--- a/Papirus/32x32/mimetypes/application-octet-stream.svg
+++ b/Papirus/32x32/mimetypes/application-octet-stream.svg
@@ -1,1 +1,1 @@
-application-x-zerosize.svg
+unknown.svg

--- a/Papirus/48x48/mimetypes/application-octet-stream.svg
+++ b/Papirus/48x48/mimetypes/application-octet-stream.svg
@@ -1,1 +1,1 @@
-application-x-zerosize.svg
+unknown.svg

--- a/Papirus/64x64/mimetypes/application-octet-stream.svg
+++ b/Papirus/64x64/mimetypes/application-octet-stream.svg
@@ -1,1 +1,1 @@
-application-x-zerosize.svg
+unknown.svg


### PR DESCRIPTION
A generic file is unknown, not empty.

Content of `/usr/share/mime/packages/freedesktop.org.xml`:
```xml
<mime-type type="application/octet-stream">
    <comment>unknown</comment>
</mime-type>

<mime-type type="application/x-zerosize">
    <comment>empty document</comment>
</mime-type>
```