### PR TITLE
[Symlink] Media replay icons for KDE

### DIFF
--- a/Papirus-Dark/16x16/actions/media-playlist-repeat-song.svg
+++ b/Papirus-Dark/16x16/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus-Dark/16x16/actions/media-repeat-single.svg
+++ b/Papirus-Dark/16x16/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus-Dark/22x22/actions/media-playlist-repeat-song.svg
+++ b/Papirus-Dark/22x22/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus-Dark/22x22/actions/media-repeat-single.svg
+++ b/Papirus-Dark/22x22/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus-Dark/24x24/actions/media-playlist-repeat-song.svg
+++ b/Papirus-Dark/24x24/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus-Dark/24x24/actions/media-repeat-single.svg
+++ b/Papirus-Dark/24x24/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus/16x16/actions/media-playlist-repeat-song.svg
+++ b/Papirus/16x16/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus/16x16/actions/media-repeat-single.svg
+++ b/Papirus/16x16/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus/22x22/actions/media-playlist-repeat-song.svg
+++ b/Papirus/22x22/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus/22x22/actions/media-repeat-single.svg
+++ b/Papirus/22x22/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus/24x24/actions/media-playlist-repeat-song.svg
+++ b/Papirus/24x24/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/Papirus/24x24/actions/media-repeat-single.svg
+++ b/Papirus/24x24/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/ePapirus/16x16/actions/media-playlist-repeat-song.svg
+++ b/ePapirus/16x16/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/ePapirus/16x16/actions/media-repeat-single.svg
+++ b/ePapirus/16x16/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/ePapirus/22x22/actions/media-playlist-repeat-song.svg
+++ b/ePapirus/22x22/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/ePapirus/22x22/actions/media-repeat-single.svg
+++ b/ePapirus/22x22/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/ePapirus/24x24/actions/media-playlist-repeat-song.svg
+++ b/ePapirus/24x24/actions/media-playlist-repeat-song.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg

--- a/ePapirus/24x24/actions/media-repeat-single.svg
+++ b/ePapirus/24x24/actions/media-repeat-single.svg
@@ -1,0 +1,1 @@
+media-repeat-track-amarok.svg


### PR DESCRIPTION
Adds two symlinks for media replay icons as seen in Elisa and in the Media Controller applet.

media-playlist-repeat-song (Applet)
media-replay-single (Elisa)