### PR TITLE
Symlink monero-gui

### DIFF
--- a/Papirus/16x16/apps/monero-gui.svg
+++ b/Papirus/16x16/apps/monero-gui.svg
@@ -1,0 +1,1 @@
+monero.svg

--- a/Papirus/22x22/apps/monero-gui.svg
+++ b/Papirus/22x22/apps/monero-gui.svg
@@ -1,0 +1,1 @@
+monero.svg

--- a/Papirus/24x24/apps/monero-gui.svg
+++ b/Papirus/24x24/apps/monero-gui.svg
@@ -1,0 +1,1 @@
+monero.svg

--- a/Papirus/32x32/apps/monero-gui.svg
+++ b/Papirus/32x32/apps/monero-gui.svg
@@ -1,0 +1,1 @@
+monero.svg

--- a/Papirus/48x48/apps/monero-gui.svg
+++ b/Papirus/48x48/apps/monero-gui.svg
@@ -1,0 +1,1 @@
+monero.svg

--- a/Papirus/64x64/apps/monero-gui.svg
+++ b/Papirus/64x64/apps/monero-gui.svg
@@ -1,0 +1,1 @@
+monero.svg


### PR DESCRIPTION
Add symlinks to Monero icon since the official Monero GUI wallet uses 'monero-gui' instead of 'monero' in its .desktop file.