### PR TITLE
Updated title for DUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Please note that some packages in the list may be outdated, open [Repology](http
 | Arch Linux    | Felix Yan            | `sudo pacman -S papirus-icon-theme` <sup>community</sup> |
 | Arch Linux    | Mohammadreza Abdollahzadeh | [papirus-icon-theme-git](https://aur.archlinux.org/packages/papirus-icon-theme-git/) <sup>AUR</sup> |
 | Debian 9+     | Yangfl               | `sudo apt install papirus-icon-theme` |
-| Debian        | Hunter Wittenborn    | [papirus-icon-theme](https://dur.hunterwittenborn.com/packages/papirus-icon-theme/) <sup>DUR</sup> |
+| Debian        | Hunter Wittenborn    | [papirus-icon-theme](https://dur.hunterwittenborn.com/packages/papirus-icon-theme/) <sup>MPR</sup> |
 | Fedora 27+    | Robert-André Mauchin | `sudo dnf install papirus-icon-theme` |
 | Fedora        | Dirk Davidis         | [papirus-icon-theme](https://copr.fedorainfracloud.org/coprs/dirkdavidis/papirus-icon-theme/) <sup>copr</sup> |
 | FreeBSD       | Hiroki Tagato        | [papirus-icon-theme](https://www.freshports.org/x11-themes/papirus-icon-theme) <sup>freshports</sup> |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Please note that some packages in the list may be outdated, open [Repology](http
 | Arch Linux    | Felix Yan            | `sudo pacman -S papirus-icon-theme` <sup>community</sup> |
 | Arch Linux    | Mohammadreza Abdollahzadeh | [papirus-icon-theme-git](https://aur.archlinux.org/packages/papirus-icon-theme-git/) <sup>AUR</sup> |
 | Debian 9+     | Yangfl               | `sudo apt install papirus-icon-theme` |
-| Debian        | Hunter Wittenborn    | [papirus-icon-theme](https://dur.hunterwittenborn.com/packages/papirus-icon-theme/) <sup>MPR</sup> |
+| Debian        | Hunter Wittenborn    | [papirus-icon-theme](https://mpr.hunterwittenborn.com/packages/papirus-icon-theme/) <sup>MPR</sup> |
 | Fedora 27+    | Robert-André Mauchin | `sudo dnf install papirus-icon-theme` |
 | Fedora        | Dirk Davidis         | [papirus-icon-theme](https://copr.fedorainfracloud.org/coprs/dirkdavidis/papirus-icon-theme/) <sup>copr</sup> |
 | FreeBSD       | Hiroki Tagato        | [papirus-icon-theme](https://www.freshports.org/x11-themes/papirus-icon-theme) <sup>freshports</sup> |


### PR DESCRIPTION
The (what was previously) DUR has been going under some ongoing changes the past week or so due to some branding issues with some people at Debian, and the repository name has now moved over to be called the makedeb Package Repository (MPR).

All the branding has already been changed, except for the URL, which will be changed to `mpr.hunterwittenborn.com` tommorow (in CDT time), as it requires some downtime for users while I move everything over on the server.

The URL itself won't need to be updated, as requests from `dur.hunterwittenborn.com` will simply be forwarded to `mpr.hunterwittenborn.com`. The only think that needs (and should) be changed at the moment is the branding for the little header next to the package's name.

The section for my package could also be moved to the Ubuntu section (as that's what the MPR is meant for first and foremost), but it doesn't really bother me one way or the other if it stays where it currently is.