### PR TITLE
remmina-status tray icon

### DIFF
--- a/Papirus-Light/16x16/panel/remmina-status.svg
+++ b/Papirus-Light/16x16/panel/remmina-status.svg
@@ -1,0 +1,1 @@
+remmina-panel.svg

--- a/Papirus-Light/22x22/panel/remmina-status.svg
+++ b/Papirus-Light/22x22/panel/remmina-status.svg
@@ -1,0 +1,1 @@
+remmina-panel.svg

--- a/Papirus-Light/24x24/panel/remmina-status.svg
+++ b/Papirus-Light/24x24/panel/remmina-status.svg
@@ -1,0 +1,1 @@
+remmina-panel.svg

--- a/Papirus/16x16/panel/remmina-status.svg
+++ b/Papirus/16x16/panel/remmina-status.svg
@@ -1,0 +1,1 @@
+remmina-panel.svg

--- a/Papirus/22x22/panel/remmina-status.svg
+++ b/Papirus/22x22/panel/remmina-status.svg
@@ -1,0 +1,1 @@
+remmina-panel.svg

--- a/Papirus/24x24/panel/remmina-status.svg
+++ b/Papirus/24x24/panel/remmina-status.svg
@@ -1,0 +1,1 @@
+remmina-panel.svg


### PR DESCRIPTION
I recently discovered that recent versions of Remmina (using version 1.4.20 here) use the name "remmina-status" for its tray icon. Previously, Remmina used either of the existing icons in the screenshot below (I'm not exactly sure which one, since both of them look the same). This PR adds a symlink for remmina-status to the original remmina-panel icon.

I've tested this on my Manjaro KDE system and can confirm that the next time I launched Remmina, the tray icon used the symlinked icon from the Papirus theme instead of the default one.

![Screenshot_20210821_202326](https://user-images.githubusercontent.com/17580077/130340285-27b16f8d-7fb2-4280-8a26-10893d9f7738.png)