### PR TITLE
Fixed installation issue when target directory contains spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,17 @@ ICON_THEMES := $(filter-out $(IGNORE), $(ICON_THEMES))
 all:
 
 install:
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons
-	cp -R $(ICON_THEMES) $(DESTDIR)$(PREFIX)/share/icons
+	mkdir -p "$(DESTDIR)$(PREFIX)/share/icons"
+	cp -R $(ICON_THEMES) "$(DESTDIR)$(PREFIX)/share/icons"
 
 # skip building icon caches when packaging
 	$(if $(DESTDIR),,$(MAKE) $(ICON_THEMES))
 
 $(ICON_THEMES):
-	-gtk-update-icon-cache -q $(DESTDIR)$(PREFIX)/share/icons/$@
+	-gtk-update-icon-cache -q "$(DESTDIR)$(PREFIX)/share/icons/$@"
 
 uninstall:
-	-rm -rf $(foreach icon_theme,$(ICON_THEMES),$(DESTDIR)$(PREFIX)/share/icons/$(icon_theme))
+	- rm -rf $(foreach icon_theme,$(ICON_THEMES),"$(DESTDIR)$(PREFIX)/share/icons/$(icon_theme)")
 
 _get_version:
 	$(eval VERSION := $(shell git show -s --format=%cd --date=format:%Y%m%d HEAD))


### PR DESCRIPTION
Previously, doing something like `make install DESTDIR="${PWD}/tmp dir"` would not act correctly due to `tmp dir` containing spaces.

The main issue comes into play when I was doing testing for some packaging. I always copy the directory before doing testing, and Nautilus (which I use as my GUI file manager) names the copied directory `foldername (copy)`, which thus causes the issue this PR aims to solve.

If it's at all feasible, it would be nice if a new release with this fix incorporated could be made as well.