### PR TITLE
Add symlinks using reverse domain name for Haguichi panel icons

### DIFF
--- a/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-connected.svg
+++ b/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-connected.svg
@@ -1,0 +1,1 @@
+haguichi-connected.svg

--- a/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-connecting-1.svg
+++ b/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-connecting-1.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-1.svg

--- a/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-connecting-2.svg
+++ b/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-connecting-2.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-2.svg

--- a/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-connecting-3.svg
+++ b/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-connecting-3.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-3.svg

--- a/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-disconnected.svg
+++ b/Papirus-Light/16x16/panel/com.github.ztefn.haguichi-disconnected.svg
@@ -1,0 +1,1 @@
+haguichi-disconnected.svg

--- a/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-connected.svg
+++ b/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-connected.svg
@@ -1,0 +1,1 @@
+haguichi-connected.svg

--- a/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-connecting-1.svg
+++ b/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-connecting-1.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-1.svg

--- a/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-connecting-2.svg
+++ b/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-connecting-2.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-2.svg

--- a/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-connecting-3.svg
+++ b/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-connecting-3.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-3.svg

--- a/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-disconnected.svg
+++ b/Papirus-Light/22x22/panel/com.github.ztefn.haguichi-disconnected.svg
@@ -1,0 +1,1 @@
+haguichi-disconnected.svg

--- a/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-connected.svg
+++ b/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-connected.svg
@@ -1,0 +1,1 @@
+haguichi-connected.svg

--- a/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-connecting-1.svg
+++ b/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-connecting-1.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-1.svg

--- a/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-connecting-2.svg
+++ b/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-connecting-2.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-2.svg

--- a/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-connecting-3.svg
+++ b/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-connecting-3.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-3.svg

--- a/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-disconnected.svg
+++ b/Papirus-Light/24x24/panel/com.github.ztefn.haguichi-disconnected.svg
@@ -1,0 +1,1 @@
+haguichi-disconnected.svg

--- a/Papirus/16x16/panel/com.github.ztefn.haguichi-connected.svg
+++ b/Papirus/16x16/panel/com.github.ztefn.haguichi-connected.svg
@@ -1,0 +1,1 @@
+haguichi-connected.svg

--- a/Papirus/16x16/panel/com.github.ztefn.haguichi-connecting-1.svg
+++ b/Papirus/16x16/panel/com.github.ztefn.haguichi-connecting-1.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-1.svg

--- a/Papirus/16x16/panel/com.github.ztefn.haguichi-connecting-2.svg
+++ b/Papirus/16x16/panel/com.github.ztefn.haguichi-connecting-2.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-2.svg

--- a/Papirus/16x16/panel/com.github.ztefn.haguichi-connecting-3.svg
+++ b/Papirus/16x16/panel/com.github.ztefn.haguichi-connecting-3.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-3.svg

--- a/Papirus/16x16/panel/com.github.ztefn.haguichi-disconnected.svg
+++ b/Papirus/16x16/panel/com.github.ztefn.haguichi-disconnected.svg
@@ -1,0 +1,1 @@
+haguichi-disconnected.svg

--- a/Papirus/22x22/panel/com.github.ztefn.haguichi-connected.svg
+++ b/Papirus/22x22/panel/com.github.ztefn.haguichi-connected.svg
@@ -1,0 +1,1 @@
+haguichi-connected.svg

--- a/Papirus/22x22/panel/com.github.ztefn.haguichi-connecting-1.svg
+++ b/Papirus/22x22/panel/com.github.ztefn.haguichi-connecting-1.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-1.svg

--- a/Papirus/22x22/panel/com.github.ztefn.haguichi-connecting-2.svg
+++ b/Papirus/22x22/panel/com.github.ztefn.haguichi-connecting-2.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-2.svg

--- a/Papirus/22x22/panel/com.github.ztefn.haguichi-connecting-3.svg
+++ b/Papirus/22x22/panel/com.github.ztefn.haguichi-connecting-3.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-3.svg

--- a/Papirus/22x22/panel/com.github.ztefn.haguichi-disconnected.svg
+++ b/Papirus/22x22/panel/com.github.ztefn.haguichi-disconnected.svg
@@ -1,0 +1,1 @@
+haguichi-disconnected.svg

--- a/Papirus/24x24/panel/com.github.ztefn.haguichi-connected.svg
+++ b/Papirus/24x24/panel/com.github.ztefn.haguichi-connected.svg
@@ -1,0 +1,1 @@
+haguichi-connected.svg

--- a/Papirus/24x24/panel/com.github.ztefn.haguichi-connecting-1.svg
+++ b/Papirus/24x24/panel/com.github.ztefn.haguichi-connecting-1.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-1.svg

--- a/Papirus/24x24/panel/com.github.ztefn.haguichi-connecting-2.svg
+++ b/Papirus/24x24/panel/com.github.ztefn.haguichi-connecting-2.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-2.svg

--- a/Papirus/24x24/panel/com.github.ztefn.haguichi-connecting-3.svg
+++ b/Papirus/24x24/panel/com.github.ztefn.haguichi-connecting-3.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-3.svg

--- a/Papirus/24x24/panel/com.github.ztefn.haguichi-disconnected.svg
+++ b/Papirus/24x24/panel/com.github.ztefn.haguichi-disconnected.svg
@@ -1,0 +1,1 @@
+haguichi-disconnected.svg

--- a/ePapirus/24x24/panel/com.github.ztefn.haguichi-connected.svg
+++ b/ePapirus/24x24/panel/com.github.ztefn.haguichi-connected.svg
@@ -1,0 +1,1 @@
+haguichi-connected.svg

--- a/ePapirus/24x24/panel/com.github.ztefn.haguichi-connecting-1.svg
+++ b/ePapirus/24x24/panel/com.github.ztefn.haguichi-connecting-1.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-1.svg

--- a/ePapirus/24x24/panel/com.github.ztefn.haguichi-connecting-2.svg
+++ b/ePapirus/24x24/panel/com.github.ztefn.haguichi-connecting-2.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-2.svg

--- a/ePapirus/24x24/panel/com.github.ztefn.haguichi-connecting-3.svg
+++ b/ePapirus/24x24/panel/com.github.ztefn.haguichi-connecting-3.svg
@@ -1,0 +1,1 @@
+haguichi-connecting-3.svg

--- a/ePapirus/24x24/panel/com.github.ztefn.haguichi-disconnected.svg
+++ b/ePapirus/24x24/panel/com.github.ztefn.haguichi-disconnected.svg
@@ -1,0 +1,1 @@
+haguichi-disconnected.svg


### PR DESCRIPTION
Next release of Haguichi (1.4.5) will be switching to reverse domain names for indicator icons. This pull requests adds symlinks for the panel icons in all Papirus icon theme variants.