### PR TITLE
ayatana-indicator-notification support

### DIFF
--- a/Papirus-Light/16x16/panel/ayatana-indicator-notification-read-dnd.svg
+++ b/Papirus-Light/16x16/panel/ayatana-indicator-notification-read-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-read-dnd.svg

--- a/Papirus-Light/16x16/panel/ayatana-indicator-notification-read.svg
+++ b/Papirus-Light/16x16/panel/ayatana-indicator-notification-read.svg
@@ -1,0 +1,1 @@
+indicator-notification-read.svg

--- a/Papirus-Light/16x16/panel/ayatana-indicator-notification-unread-dnd.svg
+++ b/Papirus-Light/16x16/panel/ayatana-indicator-notification-unread-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread-dnd.svg

--- a/Papirus-Light/16x16/panel/ayatana-indicator-notification-unread.svg
+++ b/Papirus-Light/16x16/panel/ayatana-indicator-notification-unread.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread.svg

--- a/Papirus-Light/22x22/panel/ayatana-indicator-notification-read-dnd.svg
+++ b/Papirus-Light/22x22/panel/ayatana-indicator-notification-read-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-read-dnd.svg

--- a/Papirus-Light/22x22/panel/ayatana-indicator-notification-read.svg
+++ b/Papirus-Light/22x22/panel/ayatana-indicator-notification-read.svg
@@ -1,0 +1,1 @@
+indicator-notification-read.svg

--- a/Papirus-Light/22x22/panel/ayatana-indicator-notification-unread-dnd.svg
+++ b/Papirus-Light/22x22/panel/ayatana-indicator-notification-unread-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread-dnd.svg

--- a/Papirus-Light/22x22/panel/ayatana-indicator-notification-unread.svg
+++ b/Papirus-Light/22x22/panel/ayatana-indicator-notification-unread.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread.svg

--- a/Papirus-Light/24x24/panel/ayatana-indicator-notification-read-dnd.svg
+++ b/Papirus-Light/24x24/panel/ayatana-indicator-notification-read-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-read-dnd.svg

--- a/Papirus-Light/24x24/panel/ayatana-indicator-notification-read.svg
+++ b/Papirus-Light/24x24/panel/ayatana-indicator-notification-read.svg
@@ -1,0 +1,1 @@
+indicator-notification-read.svg

--- a/Papirus-Light/24x24/panel/ayatana-indicator-notification-unread-dnd.svg
+++ b/Papirus-Light/24x24/panel/ayatana-indicator-notification-unread-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread-dnd.svg

--- a/Papirus-Light/24x24/panel/ayatana-indicator-notification-unread.svg
+++ b/Papirus-Light/24x24/panel/ayatana-indicator-notification-unread.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread.svg

--- a/Papirus/16x16/panel/ayatana-indicator-notification-read-dnd.svg
+++ b/Papirus/16x16/panel/ayatana-indicator-notification-read-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-read-dnd.svg

--- a/Papirus/16x16/panel/ayatana-indicator-notification-read.svg
+++ b/Papirus/16x16/panel/ayatana-indicator-notification-read.svg
@@ -1,0 +1,1 @@
+indicator-notification-read.svg

--- a/Papirus/16x16/panel/ayatana-indicator-notification-unread-dnd.svg
+++ b/Papirus/16x16/panel/ayatana-indicator-notification-unread-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread-dnd.svg

--- a/Papirus/16x16/panel/ayatana-indicator-notification-unread.svg
+++ b/Papirus/16x16/panel/ayatana-indicator-notification-unread.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread.svg

--- a/Papirus/22x22/panel/ayatana-indicator-notification-read-dnd.svg
+++ b/Papirus/22x22/panel/ayatana-indicator-notification-read-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-read-dnd.svg

--- a/Papirus/22x22/panel/ayatana-indicator-notification-read.svg
+++ b/Papirus/22x22/panel/ayatana-indicator-notification-read.svg
@@ -1,0 +1,1 @@
+indicator-notification-read.svg

--- a/Papirus/22x22/panel/ayatana-indicator-notification-unread-dnd.svg
+++ b/Papirus/22x22/panel/ayatana-indicator-notification-unread-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread-dnd.svg

--- a/Papirus/22x22/panel/ayatana-indicator-notification-unread.svg
+++ b/Papirus/22x22/panel/ayatana-indicator-notification-unread.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread.svg

--- a/Papirus/24x24/panel/ayatana-indicator-notification-read-dnd.svg
+++ b/Papirus/24x24/panel/ayatana-indicator-notification-read-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-read-dnd.svg

--- a/Papirus/24x24/panel/ayatana-indicator-notification-read.svg
+++ b/Papirus/24x24/panel/ayatana-indicator-notification-read.svg
@@ -1,0 +1,1 @@
+indicator-notification-read.svg

--- a/Papirus/24x24/panel/ayatana-indicator-notification-unread-dnd.svg
+++ b/Papirus/24x24/panel/ayatana-indicator-notification-unread-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread-dnd.svg

--- a/Papirus/24x24/panel/ayatana-indicator-notification-unread.svg
+++ b/Papirus/24x24/panel/ayatana-indicator-notification-unread.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread.svg

--- a/ePapirus/24x24/panel/ayatana-indicator-notification-read-dnd.svg
+++ b/ePapirus/24x24/panel/ayatana-indicator-notification-read-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-read-dnd.svg

--- a/ePapirus/24x24/panel/ayatana-indicator-notification-read.svg
+++ b/ePapirus/24x24/panel/ayatana-indicator-notification-read.svg
@@ -1,0 +1,1 @@
+indicator-notification-read.svg

--- a/ePapirus/24x24/panel/ayatana-indicator-notification-unread-dnd.svg
+++ b/ePapirus/24x24/panel/ayatana-indicator-notification-unread-dnd.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread-dnd.svg

--- a/ePapirus/24x24/panel/ayatana-indicator-notification-unread.svg
+++ b/ePapirus/24x24/panel/ayatana-indicator-notification-unread.svg
@@ -1,0 +1,1 @@
+indicator-notification-unread.svg


### PR DESCRIPTION

[ayatana-indicator-notifications](https://github.com/AyatanaIndicators/ayatana-indicator-notifications) is using the following icons:
```c
ayatana-indicator-notification-unread-dnd
ayatana-indicator-notification-unread
ayatana-indicator-notification-read-dnd
ayatana-indicator-notification-read
```
(from https://github.com/AyatanaIndicators/ayatana-indicator-notifications/blob/main/src/service.c#L279)

papirus currently contains only these icons:
```c
indicator-notification-unread-dnd
indicator-notification-unread
indicator-notification-read-dnd
indicator-notification-read
```

This PR creates symlinks to support ayatana indicators.

Before:

![Screenshot at 2021-10-28 22-24-42](https://user-images.githubusercontent.com/49864414/139348945-f4d9f1ee-4b68-469a-8a72-9a030e95d5cd.png)


After:

![Screenshot at 2021-10-28 22-25-45](https://user-images.githubusercontent.com/49864414/139349059-4b454eb7-1654-406c-9f36-9f9d41da93a9.png)


![Screenshot at 2021-10-28 22-25-29](https://user-images.githubusercontent.com/49864414/139348958-2d02b767-f1c9-4174-beae-1d7d63554f08.png)

