### PR TITLE
Added symlinks for the new mesen icon name

### DIFF
--- a/Papirus/16x16/apps/MesenIcon.svg
+++ b/Papirus/16x16/apps/MesenIcon.svg
@@ -1,0 +1,1 @@
+mesen.svg

--- a/Papirus/22x22/apps/MesenIcon.svg
+++ b/Papirus/22x22/apps/MesenIcon.svg
@@ -1,0 +1,1 @@
+mesen.svg

--- a/Papirus/24x24/apps/MesenIcon.svg
+++ b/Papirus/24x24/apps/MesenIcon.svg
@@ -1,0 +1,1 @@
+mesen.svg

--- a/Papirus/32x32/apps/MesenIcon.svg
+++ b/Papirus/32x32/apps/MesenIcon.svg
@@ -1,0 +1,1 @@
+mesen.svg

--- a/Papirus/48x48/apps/MesenIcon.svg
+++ b/Papirus/48x48/apps/MesenIcon.svg
@@ -1,0 +1,1 @@
+mesen.svg

--- a/Papirus/64x64/apps/MesenIcon.svg
+++ b/Papirus/64x64/apps/MesenIcon.svg
@@ -1,0 +1,1 @@
+mesen.svg


### PR DESCRIPTION
This just makes a symlink so that the mesen emulator icon appears since they changed the name of it.
(The user who made the commit is wrong because I was using the wrong email on git)