### PR TITLE
New Mathematica mimetype symlinks

### DIFF
--- a/Papirus/16x16/mimetypes/application-mathematica.svg
+++ b/Papirus/16x16/mimetypes/application-mathematica.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.nb.svg

--- a/Papirus/16x16/mimetypes/application-mathematicaplayer.svg
+++ b/Papirus/16x16/mimetypes/application-mathematicaplayer.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.cdf.svg

--- a/Papirus/22x22/mimetypes/application-mathematica.svg
+++ b/Papirus/22x22/mimetypes/application-mathematica.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.nb.svg

--- a/Papirus/22x22/mimetypes/application-mathematicaplayer.svg
+++ b/Papirus/22x22/mimetypes/application-mathematicaplayer.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.cdf.svg

--- a/Papirus/24x24/mimetypes/application-mathematica.svg
+++ b/Papirus/24x24/mimetypes/application-mathematica.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.nb.svg

--- a/Papirus/24x24/mimetypes/application-mathematicaplayer.svg
+++ b/Papirus/24x24/mimetypes/application-mathematicaplayer.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.cdf.svg

--- a/Papirus/32x32/mimetypes/application-mathematica.svg
+++ b/Papirus/32x32/mimetypes/application-mathematica.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.nb.svg

--- a/Papirus/32x32/mimetypes/application-mathematicaplayer.svg
+++ b/Papirus/32x32/mimetypes/application-mathematicaplayer.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.cdf.svg

--- a/Papirus/48x48/mimetypes/application-mathematica.svg
+++ b/Papirus/48x48/mimetypes/application-mathematica.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.nb.svg

--- a/Papirus/48x48/mimetypes/application-mathematicaplayer.svg
+++ b/Papirus/48x48/mimetypes/application-mathematicaplayer.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.cdf.svg

--- a/Papirus/64x64/mimetypes/application-mathematica.svg
+++ b/Papirus/64x64/mimetypes/application-mathematica.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.nb.svg

--- a/Papirus/64x64/mimetypes/application-mathematicaplayer.svg
+++ b/Papirus/64x64/mimetypes/application-mathematicaplayer.svg
@@ -1,0 +1,1 @@
+application-vnd.wolfram.cdf.svg


### PR DESCRIPTION
Wolfram seems to have changed the some of the names of the default mimetypes referenced in Mathematica  12.3. This adds symlinks to the original mimetypes.