### PR TITLE
Symlinked duolingo to ro.go.hmlendea.DL-Desktop

### DIFF
--- a/Papirus/16x16/apps/ro.go.hmlendea.DL-Desktop.svg
+++ b/Papirus/16x16/apps/ro.go.hmlendea.DL-Desktop.svg
@@ -1,0 +1,1 @@
+duolingo.svg

--- a/Papirus/22x22/apps/ro.go.hmlendea.DL-Desktop.svg
+++ b/Papirus/22x22/apps/ro.go.hmlendea.DL-Desktop.svg
@@ -1,0 +1,1 @@
+duolingo.svg

--- a/Papirus/24x24/apps/ro.go.hmlendea.DL-Desktop.svg
+++ b/Papirus/24x24/apps/ro.go.hmlendea.DL-Desktop.svg
@@ -1,0 +1,1 @@
+duolingo.svg

--- a/Papirus/32x32/apps/ro.go.hmlendea.DL-Desktop.svg
+++ b/Papirus/32x32/apps/ro.go.hmlendea.DL-Desktop.svg
@@ -1,0 +1,1 @@
+duolingo.svg

--- a/Papirus/48x48/apps/ro.go.hmlendea.DL-Desktop.svg
+++ b/Papirus/48x48/apps/ro.go.hmlendea.DL-Desktop.svg
@@ -1,0 +1,1 @@
+duolingo.svg

--- a/Papirus/64x64/apps/ro.go.hmlendea.DL-Desktop.svg
+++ b/Papirus/64x64/apps/ro.go.hmlendea.DL-Desktop.svg
@@ -1,0 +1,1 @@
+duolingo.svg


### PR DESCRIPTION
(Symlink) Icon for the flatpak version of Duolingo: https://flathub.org/apps/details/ro.go.hmlendea.DL-Desktop