### PR TITLE
Add links for whatspp-for-linux (new app ID)

### DIFF
--- a/Papirus-Light/16x16/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
+++ b/Papirus-Light/16x16/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
@@ -1,0 +1,1 @@
+whatsapp-msg.svg

--- a/Papirus-Light/16x16/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
+++ b/Papirus-Light/16x16/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
@@ -1,0 +1,1 @@
+whatsapp-tray.svg

--- a/Papirus-Light/22x22/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
+++ b/Papirus-Light/22x22/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
@@ -1,0 +1,1 @@
+whatsapp-msg.svg

--- a/Papirus-Light/22x22/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
+++ b/Papirus-Light/22x22/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
@@ -1,0 +1,1 @@
+whatsapp-tray.svg

--- a/Papirus-Light/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
+++ b/Papirus-Light/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
@@ -1,0 +1,1 @@
+whatsapp-msg.svg

--- a/Papirus-Light/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
+++ b/Papirus-Light/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
@@ -1,0 +1,1 @@
+whatsapp-tray.svg

--- a/Papirus/16x16/apps/com.github.eneshecan.WhatsAppForLinux.svg
+++ b/Papirus/16x16/apps/com.github.eneshecan.WhatsAppForLinux.svg
@@ -1,0 +1,1 @@
+whatsapp.svg

--- a/Papirus/16x16/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
+++ b/Papirus/16x16/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
@@ -1,0 +1,1 @@
+whatsapp-msg.svg

--- a/Papirus/16x16/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
+++ b/Papirus/16x16/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
@@ -1,0 +1,1 @@
+whatsapp-tray.svg

--- a/Papirus/22x22/apps/com.github.eneshecan.WhatsAppForLinux.svg
+++ b/Papirus/22x22/apps/com.github.eneshecan.WhatsAppForLinux.svg
@@ -1,0 +1,1 @@
+whatsapp.svg

--- a/Papirus/22x22/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
+++ b/Papirus/22x22/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
@@ -1,0 +1,1 @@
+whatsapp-msg.svg

--- a/Papirus/22x22/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
+++ b/Papirus/22x22/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
@@ -1,0 +1,1 @@
+whatsapp-tray.svg

--- a/Papirus/24x24/apps/com.github.eneshecan.WhatsAppForLinux.svg
+++ b/Papirus/24x24/apps/com.github.eneshecan.WhatsAppForLinux.svg
@@ -1,0 +1,1 @@
+whatsapp.svg

--- a/Papirus/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
+++ b/Papirus/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
@@ -1,0 +1,1 @@
+whatsapp-msg.svg

--- a/Papirus/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
+++ b/Papirus/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
@@ -1,0 +1,1 @@
+whatsapp-tray.svg

--- a/Papirus/32x32/apps/com.github.eneshecan.WhatsAppForLinux.svg
+++ b/Papirus/32x32/apps/com.github.eneshecan.WhatsAppForLinux.svg
@@ -1,0 +1,1 @@
+whatsapp.svg

--- a/Papirus/48x48/apps/com.github.eneshecan.WhatsAppForLinux.svg
+++ b/Papirus/48x48/apps/com.github.eneshecan.WhatsAppForLinux.svg
@@ -1,0 +1,1 @@
+whatsapp.svg

--- a/Papirus/64x64/apps/com.github.eneshecan.WhatsAppForLinux.svg
+++ b/Papirus/64x64/apps/com.github.eneshecan.WhatsAppForLinux.svg
@@ -1,0 +1,1 @@
+whatsapp.svg

--- a/ePapirus/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
+++ b/ePapirus/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray-attention.svg
@@ -1,0 +1,1 @@
+whatsapp-msg.svg

--- a/ePapirus/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
+++ b/ePapirus/24x24/panel/com.github.eneshecan.WhatsAppForLinux-tray.svg
@@ -1,0 +1,1 @@
+whatsapp-tray.svg


### PR DESCRIPTION
In recent versions of `whatsapp-for-linux`, the application ID has changed to `com.github.eneshecan.WhatsAppForLinux`, and icons have been renamed as follows:

**App icon**:

![com github eneshecan WhatsAppForLinux](https://user-images.githubusercontent.com/18715287/166962446-96e83f28-31ba-4343-afe2-e5f1d39a2ad1.png)
/usr/share/icons/hicolor/\<size\>/apps/com.github.eneshecan.WhatsAppForLinux.png

**Status icons**:
![com github eneshecan WhatsAppForLinux-tray](https://user-images.githubusercontent.com/18715287/166962554-67993b19-acc1-42c3-89e4-fbc8bded9eb7.png)
/usr/share/icons/hicolor/\<size\>/status/com.github.eneshecan.WhatsAppForLinux-tray.png

![com github eneshecan WhatsAppForLinux-tray-attention](https://user-images.githubusercontent.com/18715287/166962590-ee80627b-c437-458e-a3fc-584cb48e7221.png)
/usr/share/icons/hicolor/\<size\>/status/com.github.eneshecan.WhatsAppForLinux-tray-attention.png