### PR TITLE
Add links for Gajim tray

### DIFF
--- a/Papirus-Light/16x16/panel/dcraven-away.svg
+++ b/Papirus-Light/16x16/panel/dcraven-away.svg
@@ -1,0 +1,1 @@
+user-away.svg

--- a/Papirus-Light/16x16/panel/dcraven-connecting.svg
+++ b/Papirus-Light/16x16/panel/dcraven-connecting.svg
@@ -1,0 +1,1 @@
+user-status-pending.svg

--- a/Papirus-Light/16x16/panel/dcraven-dnd.svg
+++ b/Papirus-Light/16x16/panel/dcraven-dnd.svg
@@ -1,0 +1,1 @@
+user-busy.svg

--- a/Papirus-Light/16x16/panel/dcraven-error.svg
+++ b/Papirus-Light/16x16/panel/dcraven-error.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus-Light/16x16/panel/dcraven-message-new.svg
+++ b/Papirus-Light/16x16/panel/dcraven-message-new.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus-Light/16x16/panel/dcraven-offline.svg
+++ b/Papirus-Light/16x16/panel/dcraven-offline.svg
@@ -1,0 +1,1 @@
+user-offline.svg

--- a/Papirus-Light/16x16/panel/dcraven-online.svg
+++ b/Papirus-Light/16x16/panel/dcraven-online.svg
@@ -1,0 +1,1 @@
+user-available.svg

--- a/Papirus-Light/16x16/panel/dcraven-xa.svg
+++ b/Papirus-Light/16x16/panel/dcraven-xa.svg
@@ -1,0 +1,1 @@
+user-idle.svg

--- a/Papirus-Light/22x22/panel/dcraven-away.svg
+++ b/Papirus-Light/22x22/panel/dcraven-away.svg
@@ -1,0 +1,1 @@
+user-away.svg

--- a/Papirus-Light/22x22/panel/dcraven-connecting.svg
+++ b/Papirus-Light/22x22/panel/dcraven-connecting.svg
@@ -1,0 +1,1 @@
+user-status-pending.svg

--- a/Papirus-Light/22x22/panel/dcraven-dnd.svg
+++ b/Papirus-Light/22x22/panel/dcraven-dnd.svg
@@ -1,0 +1,1 @@
+user-busy.svg

--- a/Papirus-Light/22x22/panel/dcraven-error.svg
+++ b/Papirus-Light/22x22/panel/dcraven-error.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus-Light/22x22/panel/dcraven-message-new.svg
+++ b/Papirus-Light/22x22/panel/dcraven-message-new.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus-Light/22x22/panel/dcraven-offline.svg
+++ b/Papirus-Light/22x22/panel/dcraven-offline.svg
@@ -1,0 +1,1 @@
+user-offline.svg

--- a/Papirus-Light/22x22/panel/dcraven-online.svg
+++ b/Papirus-Light/22x22/panel/dcraven-online.svg
@@ -1,0 +1,1 @@
+user-available.svg

--- a/Papirus-Light/22x22/panel/dcraven-xa.svg
+++ b/Papirus-Light/22x22/panel/dcraven-xa.svg
@@ -1,0 +1,1 @@
+user-idle.svg

--- a/Papirus-Light/24x24/panel/dcraven-away.svg
+++ b/Papirus-Light/24x24/panel/dcraven-away.svg
@@ -1,0 +1,1 @@
+user-away.svg

--- a/Papirus-Light/24x24/panel/dcraven-connecting.svg
+++ b/Papirus-Light/24x24/panel/dcraven-connecting.svg
@@ -1,0 +1,1 @@
+user-status-pending.svg

--- a/Papirus-Light/24x24/panel/dcraven-dnd.svg
+++ b/Papirus-Light/24x24/panel/dcraven-dnd.svg
@@ -1,0 +1,1 @@
+user-busy.svg

--- a/Papirus-Light/24x24/panel/dcraven-error.svg
+++ b/Papirus-Light/24x24/panel/dcraven-error.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus-Light/24x24/panel/dcraven-message-new.svg
+++ b/Papirus-Light/24x24/panel/dcraven-message-new.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus-Light/24x24/panel/dcraven-offline.svg
+++ b/Papirus-Light/24x24/panel/dcraven-offline.svg
@@ -1,0 +1,1 @@
+user-offline.svg

--- a/Papirus-Light/24x24/panel/dcraven-online.svg
+++ b/Papirus-Light/24x24/panel/dcraven-online.svg
@@ -1,0 +1,1 @@
+user-available.svg

--- a/Papirus-Light/24x24/panel/dcraven-xa.svg
+++ b/Papirus-Light/24x24/panel/dcraven-xa.svg
@@ -1,0 +1,1 @@
+user-idle.svg

--- a/Papirus/16x16/panel/dcraven-away.svg
+++ b/Papirus/16x16/panel/dcraven-away.svg
@@ -1,0 +1,1 @@
+user-away.svg

--- a/Papirus/16x16/panel/dcraven-connecting.svg
+++ b/Papirus/16x16/panel/dcraven-connecting.svg
@@ -1,0 +1,1 @@
+user-status-pending.svg

--- a/Papirus/16x16/panel/dcraven-dnd.svg
+++ b/Papirus/16x16/panel/dcraven-dnd.svg
@@ -1,0 +1,1 @@
+user-busy.svg

--- a/Papirus/16x16/panel/dcraven-error.svg
+++ b/Papirus/16x16/panel/dcraven-error.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus/16x16/panel/dcraven-message-new.svg
+++ b/Papirus/16x16/panel/dcraven-message-new.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus/16x16/panel/dcraven-offline.svg
+++ b/Papirus/16x16/panel/dcraven-offline.svg
@@ -1,0 +1,1 @@
+user-offline.svg

--- a/Papirus/16x16/panel/dcraven-online.svg
+++ b/Papirus/16x16/panel/dcraven-online.svg
@@ -1,0 +1,1 @@
+user-available.svg

--- a/Papirus/16x16/panel/dcraven-xa.svg
+++ b/Papirus/16x16/panel/dcraven-xa.svg
@@ -1,0 +1,1 @@
+user-idle.svg

--- a/Papirus/22x22/panel/dcraven-away.svg
+++ b/Papirus/22x22/panel/dcraven-away.svg
@@ -1,0 +1,1 @@
+user-away.svg

--- a/Papirus/22x22/panel/dcraven-connecting.svg
+++ b/Papirus/22x22/panel/dcraven-connecting.svg
@@ -1,0 +1,1 @@
+user-status-pending.svg

--- a/Papirus/22x22/panel/dcraven-dnd.svg
+++ b/Papirus/22x22/panel/dcraven-dnd.svg
@@ -1,0 +1,1 @@
+user-busy.svg

--- a/Papirus/22x22/panel/dcraven-error.svg
+++ b/Papirus/22x22/panel/dcraven-error.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus/22x22/panel/dcraven-message-new.svg
+++ b/Papirus/22x22/panel/dcraven-message-new.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus/22x22/panel/dcraven-offline.svg
+++ b/Papirus/22x22/panel/dcraven-offline.svg
@@ -1,0 +1,1 @@
+user-offline.svg

--- a/Papirus/22x22/panel/dcraven-online.svg
+++ b/Papirus/22x22/panel/dcraven-online.svg
@@ -1,0 +1,1 @@
+user-available.svg

--- a/Papirus/22x22/panel/dcraven-xa.svg
+++ b/Papirus/22x22/panel/dcraven-xa.svg
@@ -1,0 +1,1 @@
+user-idle.svg

--- a/Papirus/24x24/panel/dcraven-away.svg
+++ b/Papirus/24x24/panel/dcraven-away.svg
@@ -1,0 +1,1 @@
+user-away.svg

--- a/Papirus/24x24/panel/dcraven-connecting.svg
+++ b/Papirus/24x24/panel/dcraven-connecting.svg
@@ -1,0 +1,1 @@
+user-status-pending.svg

--- a/Papirus/24x24/panel/dcraven-dnd.svg
+++ b/Papirus/24x24/panel/dcraven-dnd.svg
@@ -1,0 +1,1 @@
+user-busy.svg

--- a/Papirus/24x24/panel/dcraven-error.svg
+++ b/Papirus/24x24/panel/dcraven-error.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus/24x24/panel/dcraven-message-new.svg
+++ b/Papirus/24x24/panel/dcraven-message-new.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/Papirus/24x24/panel/dcraven-offline.svg
+++ b/Papirus/24x24/panel/dcraven-offline.svg
@@ -1,0 +1,1 @@
+user-offline.svg

--- a/Papirus/24x24/panel/dcraven-online.svg
+++ b/Papirus/24x24/panel/dcraven-online.svg
@@ -1,0 +1,1 @@
+user-available.svg

--- a/Papirus/24x24/panel/dcraven-xa.svg
+++ b/Papirus/24x24/panel/dcraven-xa.svg
@@ -1,0 +1,1 @@
+user-idle.svg

--- a/ePapirus/24x24/panel/dcraven-away.svg
+++ b/ePapirus/24x24/panel/dcraven-away.svg
@@ -1,0 +1,1 @@
+user-away.svg

--- a/ePapirus/24x24/panel/dcraven-connecting.svg
+++ b/ePapirus/24x24/panel/dcraven-connecting.svg
@@ -1,0 +1,1 @@
+user-status-pending.svg

--- a/ePapirus/24x24/panel/dcraven-dnd.svg
+++ b/ePapirus/24x24/panel/dcraven-dnd.svg
@@ -1,0 +1,1 @@
+user-busy.svg

--- a/ePapirus/24x24/panel/dcraven-error.svg
+++ b/ePapirus/24x24/panel/dcraven-error.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/ePapirus/24x24/panel/dcraven-message-new.svg
+++ b/ePapirus/24x24/panel/dcraven-message-new.svg
@@ -1,0 +1,1 @@
+user-status-new.svg

--- a/ePapirus/24x24/panel/dcraven-offline.svg
+++ b/ePapirus/24x24/panel/dcraven-offline.svg
@@ -1,0 +1,1 @@
+user-offline.svg

--- a/ePapirus/24x24/panel/dcraven-online.svg
+++ b/ePapirus/24x24/panel/dcraven-online.svg
@@ -1,0 +1,1 @@
+user-available.svg

--- a/ePapirus/24x24/panel/dcraven-xa.svg
+++ b/ePapirus/24x24/panel/dcraven-xa.svg
@@ -1,0 +1,1 @@
+user-idle.svg


### PR DESCRIPTION
Gajim use [more icons](https://dev.gajim.org/gajim/gajim/-/tree/master/gajim/data/icons/hicolor/scalable/status) (tray icons are prefixed with `dcraven-`), but with no matching icons in Papirus.
Gajim specific icons should probably be created to correctly cover the set 😅