### PR TITLE
Fix skanlite icon

### DIFF
--- a/Papirus/16x16/apps/org.kde.skanlite.svg
+++ b/Papirus/16x16/apps/org.kde.skanlite.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/22x22/apps/org.kde.skanlite.svg
+++ b/Papirus/22x22/apps/org.kde.skanlite.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/24x24/apps/org.kde.skanlite.svg
+++ b/Papirus/24x24/apps/org.kde.skanlite.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/32x32/apps/org.kde.skanlite.svg
+++ b/Papirus/32x32/apps/org.kde.skanlite.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/48x48/apps/org.kde.skanlite.svg
+++ b/Papirus/48x48/apps/org.kde.skanlite.svg
@@ -1,0 +1,1 @@
+skanlite.svg

--- a/Papirus/64x64/apps/org.kde.skanlite.svg
+++ b/Papirus/64x64/apps/org.kde.skanlite.svg
@@ -1,0 +1,1 @@
+skanlite.svg


### PR DESCRIPTION
Skanlite from ArchLinux repository uses `org.kde.skanlite` icon instead `skanlite`