### PR TITLE
Add symlink for Plex Desktop

### DIFF
--- a/Papirus/16x16/apps/plex-desktop.svg
+++ b/Papirus/16x16/apps/plex-desktop.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg

--- a/Papirus/22x22/apps/plex-desktop.svg
+++ b/Papirus/22x22/apps/plex-desktop.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg

--- a/Papirus/24x24/apps/plex-desktop.svg
+++ b/Papirus/24x24/apps/plex-desktop.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg

--- a/Papirus/32x32/apps/plex-desktop.svg
+++ b/Papirus/32x32/apps/plex-desktop.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg

--- a/Papirus/48x48/apps/plex-desktop.svg
+++ b/Papirus/48x48/apps/plex-desktop.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg

--- a/Papirus/64x64/apps/plex-desktop.svg
+++ b/Papirus/64x64/apps/plex-desktop.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg


### PR DESCRIPTION
Plex recently released their new Plex app for Linux, which uses the icon name - plex-desktop.

Symlinks plex-desktop.svg to plexhometheater.svg.