### PR TITLE
Add symlinks for new RSS Guard app ids

### DIFF
--- a/Papirus/16x16/apps/io.github.martinrotter.rssguard.svg
+++ b/Papirus/16x16/apps/io.github.martinrotter.rssguard.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/16x16/apps/io.github.martinrotter.rssguardlite.svg
+++ b/Papirus/16x16/apps/io.github.martinrotter.rssguardlite.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/22x22/apps/io.github.martinrotter.rssguard.svg
+++ b/Papirus/22x22/apps/io.github.martinrotter.rssguard.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/22x22/apps/io.github.martinrotter.rssguardlite.svg
+++ b/Papirus/22x22/apps/io.github.martinrotter.rssguardlite.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/24x24/apps/io.github.martinrotter.rssguard.svg
+++ b/Papirus/24x24/apps/io.github.martinrotter.rssguard.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/24x24/apps/io.github.martinrotter.rssguardlite.svg
+++ b/Papirus/24x24/apps/io.github.martinrotter.rssguardlite.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/32x32/apps/io.github.martinrotter.rssguard.svg
+++ b/Papirus/32x32/apps/io.github.martinrotter.rssguard.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/32x32/apps/io.github.martinrotter.rssguardlite.svg
+++ b/Papirus/32x32/apps/io.github.martinrotter.rssguardlite.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/48x48/apps/io.github.martinrotter.rssguard.svg
+++ b/Papirus/48x48/apps/io.github.martinrotter.rssguard.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/48x48/apps/io.github.martinrotter.rssguardlite.svg
+++ b/Papirus/48x48/apps/io.github.martinrotter.rssguardlite.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/64x64/apps/io.github.martinrotter.rssguard.svg
+++ b/Papirus/64x64/apps/io.github.martinrotter.rssguard.svg
@@ -1,0 +1,1 @@
+rssguard.svg

--- a/Papirus/64x64/apps/io.github.martinrotter.rssguardlite.svg
+++ b/Papirus/64x64/apps/io.github.martinrotter.rssguardlite.svg
@@ -1,0 +1,1 @@
+rssguard.svg


### PR DESCRIPTION
Starting from version 4.3.0 (probably), RSS Guard will have two separate app ids:

- io.github.martinrotter.rssguard (official build, with built-in web browser support)
- io.github.martinrotter.rssguardlite (official build, no built-in web browser support)

These two new ids had to be created from scratch, instead of just re-using the previous one (com.github.rssguard) to create the 'lite' variant.

That's because the old id is considered invalid by today's Flatpak naming standards, so it would not be possible to re-use it.

Upstream PR: https://github.com/martinrotter/rssguard/pull/836