### PR TITLE
Symlinked slimbook battery to references-system-power

### DIFF
--- a/Papirus/16x16/apps/slimbookbattery.svg
+++ b/Papirus/16x16/apps/slimbookbattery.svg
@@ -1,0 +1,1 @@
+preferences-system-power.svg

--- a/Papirus/22x22/apps/slimbookbattery.svg
+++ b/Papirus/22x22/apps/slimbookbattery.svg
@@ -1,0 +1,1 @@
+preferences-system-power.svg

--- a/Papirus/24x24/apps/slimbookbattery.svg
+++ b/Papirus/24x24/apps/slimbookbattery.svg
@@ -1,0 +1,1 @@
+preferences-system-power.svg

--- a/Papirus/32x32/apps/slimbookbattery.svg
+++ b/Papirus/32x32/apps/slimbookbattery.svg
@@ -1,0 +1,1 @@
+preferences-system-power.svg

--- a/Papirus/48x48/apps/slimbookbattery.svg
+++ b/Papirus/48x48/apps/slimbookbattery.svg
@@ -1,0 +1,1 @@
+preferences-system-power.svg

--- a/Papirus/64x64/apps/slimbookbattery.svg
+++ b/Papirus/64x64/apps/slimbookbattery.svg
@@ -1,0 +1,1 @@
+preferences-system-power.svg


### PR DESCRIPTION
Added a symlink for now. If needed will create an icon.