### PR TITLE
Add ProtonUp-Qt symlink

### DIFF
--- a/Papirus/16x16/apps/protonup-qt.svg
+++ b/Papirus/16x16/apps/protonup-qt.svg
@@ -1,0 +1,1 @@
+net.davidotek.pupgui2.svg

--- a/Papirus/22x22/apps/protonup-qt.svg
+++ b/Papirus/22x22/apps/protonup-qt.svg
@@ -1,0 +1,1 @@
+net.davidotek.pupgui2.svg

--- a/Papirus/24x24/apps/protonup-qt.svg
+++ b/Papirus/24x24/apps/protonup-qt.svg
@@ -1,0 +1,1 @@
+net.davidotek.pupgui2.svg

--- a/Papirus/32x32/apps/protonup-qt.svg
+++ b/Papirus/32x32/apps/protonup-qt.svg
@@ -1,0 +1,1 @@
+net.davidotek.pupgui2.svg

--- a/Papirus/48x48/apps/protonup-qt.svg
+++ b/Papirus/48x48/apps/protonup-qt.svg
@@ -1,0 +1,1 @@
+net.davidotek.pupgui2.svg

--- a/Papirus/64x64/apps/protonup-qt.svg
+++ b/Papirus/64x64/apps/protonup-qt.svg
@@ -1,0 +1,1 @@
+net.davidotek.pupgui2.svg


### PR DESCRIPTION
some linux distributions like NixOS use the icon name `protonup-qt`