### PR TITLE
Add icons for Arianna

### DIFF
--- a/Papirus/16x16/apps/arianna.svg
+++ b/Papirus/16x16/apps/arianna.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" version="1.1">
+ <rect style="fill:#e97e10" width="14" height="16" x="1" y="0" rx=".8" ry=".8"/>
+ <path fill="#e4e4e4" d="m10 0v7h2v-7z"/>
+ <path style="opacity:0.2" d="M 1.8008 0 C 1.3576 0 1 0.35758 1 0.80078 L 1 15.199 C 1 15.642 1.3576 16 1.8008 16 L 3 16 L 3 0 L 1.8008 0 z"/>
+</svg>

--- a/Papirus/16x16/apps/org.kde.arianna.svg
+++ b/Papirus/16x16/apps/org.kde.arianna.svg
@@ -1,0 +1,1 @@
+arianna.svg

--- a/Papirus/22x22/apps/arianna.svg
+++ b/Papirus/22x22/apps/arianna.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" version="1.1">
+ <g transform="translate(-1,-1)">
+  <rect style="opacity:0.2" width="18" height="20" x="3" y="2.5" rx="1" ry="1"/>
+  <rect style="fill:#e97e10" width="18" height="20" x="3" y="2" rx="1" ry="1"/>
+  <path style="opacity:0.2" d="M 15,2.5 V 13.5 L 16,12.5 H 17 L 18,13.5 V 2.5 Z"/>
+  <path style="fill:#e4e4e4" d="M 15,2 V 13 L 16,12 H 17 L 18,13 V 2 Z"/>
+  <path style="opacity:0.2" d="M 4,2 C 3.446,2 3,2.446 3,3 V 21 C 3,21.554 3.446,22 4,22 H 6 V 2 Z"/>
+  <path style="opacity:0.2;fill:#ffffff" d="M 4,2 C 3.446,2 3,2.446 3,3 V 3.5 C 3,2.946 3.446,2.5 4,2.5 H 20 C 20.554,2.5 21,2.946 21,3.5 V 3 C 21,2.446 20.554,2 20,2 Z"/>
+ </g>
+</svg>

--- a/Papirus/22x22/apps/org.kde.arianna.svg
+++ b/Papirus/22x22/apps/org.kde.arianna.svg
@@ -1,0 +1,1 @@
+arianna.svg

--- a/Papirus/24x24/apps/arianna.svg
+++ b/Papirus/24x24/apps/arianna.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" version="1.1">
+ <rect style="opacity:0.2" width="18" height="20" x="3" y="2.5" rx="1" ry="1"/>
+ <rect style="fill:#e97e10" width="18" height="20" x="3" y="2" rx="1" ry="1"/>
+ <path style="opacity:0.2" d="M 15,2.5 V 13.5 L 16,12.5 H 17 L 18,13.5 V 2.5 Z"/>
+ <path style="fill:#e4e4e4" d="m15 2v11l1-1h1l1 1v-11z"/>
+ <path style="opacity:0.2" d="M 4 2 C 3.446 2 3 2.446 3 3 L 3 21 C 3 21.554 3.446 22 4 22 L 6 22 L 6 2 L 4 2 z"/>
+ <path style="opacity:0.2;fill:#ffffff" d="M 4 2 C 3.446 2 3 2.446 3 3 L 3 3.5 C 3 2.946 3.446 2.5 4 2.5 L 20 2.5 C 20.554 2.5 21 2.946 21 3.5 L 21 3 C 21 2.446 20.554 2 20 2 L 4 2 z"/>
+</svg>

--- a/Papirus/24x24/apps/org.kde.arianna.svg
+++ b/Papirus/24x24/apps/org.kde.arianna.svg
@@ -1,0 +1,1 @@
+arianna.svg

--- a/Papirus/32x32/apps/arianna.svg
+++ b/Papirus/32x32/apps/arianna.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" version="1.1">
+ <rect style="opacity:0.2" width="22" height="28" x="5" y="3" rx="1.5" ry="1.5"/>
+ <rect style="fill:#e97e10" width="22" height="28" x="5" y="2" rx="1.5" ry="1.5"/>
+ <path style="opacity:0.2" d="M 19,3 V 17 L 21,15 23,17 V 3 Z"/>
+ <path fill="#e4e4e4" d="m19 2v14l2-2 2 2v-14h-4z"/>
+ <path style="opacity:0.2" d="M 6.5 2 C 5.669 2 5 2.669 5 3.5 L 5 28.5 C 5 29.331 5.669 30 6.5 30 L 9 30 L 9 2 L 6.5 2 z"/>
+ <path style="opacity:0.2;fill:#ffffff" d="M 6.5 2 C 5.669 2 5 2.669 5 3.5 L 5 4.5 C 5 3.669 5.669 3 6.5 3 L 25.5 3 C 26.331 3 27 3.669 27 4.5 L 27 3.5 C 27 2.669 26.331 2 25.5 2 L 6.5 2 z"/>
+</svg>

--- a/Papirus/32x32/apps/org.kde.arianna.svg
+++ b/Papirus/32x32/apps/org.kde.arianna.svg
@@ -1,0 +1,1 @@
+arianna.svg

--- a/Papirus/48x48/apps/arianna.svg
+++ b/Papirus/48x48/apps/arianna.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" version="1.1">
+ <rect style="opacity:0.2" width="32" height="40" x="8" y="5" rx="2" ry="2"/>
+ <rect style="fill:#e97e10" width="32" height="40" x="8" y="4" rx="2" ry="2"/>
+ <path style="opacity:0.2" d="M 31,5 V 21.5 L 33.5,20 36,21.5 V 5 Z"/>
+ <path style="fill:#e4e4e4" d="M 31,4 V 20.5 L 33.5,19 36,20.5 V 4 Z"/>
+ <path style="opacity:0.2" d="M 10 4 C 8.892 4 8 4.892 8 6 L 8 42 C 8 43.108 8.892 44 10 44 L 14 44 L 14 4 L 10 4 z"/>
+ <path style="opacity:0.2;fill:#ffffff" d="M 10 4 C 8.892 4 8 4.892 8 6 L 8 7 C 8 5.892 8.892 5 10 5 L 38 5 C 39.108 5 40 5.892 40 7 L 40 6 C 40 4.892 39.108 4 38 4 L 10 4 z"/>
+</svg>

--- a/Papirus/48x48/apps/org.kde.arianna.svg
+++ b/Papirus/48x48/apps/org.kde.arianna.svg
@@ -1,0 +1,1 @@
+arianna.svg

--- a/Papirus/64x64/apps/arianna.svg
+++ b/Papirus/64x64/apps/arianna.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" version="1.1">
+ <rect style="opacity:0.2" width="44" height="56" x="10" y="5" rx="3" ry="3"/>
+ <rect style="fill:#e97e10" width="44" height="56" x="10" y="4" rx="3" ry="3"/>
+ <path style="opacity:0.2" d="M 38,5 V 33 L 42,29 46,33 V 5 Z"/>
+ <path style="fill:#e4e4e4" d="m 38,4 0,28 4,-4 4,4 0,-28 -8,0 z"/>
+ <path style="opacity:0.2" d="M 13 4 C 11.338 4 10 5.338 10 7 L 10 57 C 10 58.662 11.338 60 13 60 L 18 60 L 18 4 L 13 4 z"/>
+ <path style="opacity:0.2;fill:#ffffff" d="M 13 4 C 11.338 4 10 5.338 10 7 L 10 8 C 10 6.338 11.338 5 13 5 L 51 5 C 52.662 5 54 6.338 54 8 L 54 7 C 54 5.338 52.662 4 51 4 L 13 4 z"/>
+</svg>

--- a/Papirus/64x64/apps/org.kde.arianna.svg
+++ b/Papirus/64x64/apps/org.kde.arianna.svg
@@ -1,0 +1,1 @@
+arianna.svg


### PR DESCRIPTION
Added icons for KDE ebook reader and library management app Arianna.
Added Flathub symlinks for Arianna.
Icons are based on `accessories-ebook-reader` icon, but recoloured to the colour of the original icon.
I recoloured them in text editor so that Inkscape doesn't inflate the file size.  

Original icon:  
![image](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/782ebe27-bf24-432f-91f4-1adff2b3cb2c)  