### PR TITLE
Add symlink for Legacy Launcher

### DIFF
--- a/Papirus/16x16/apps/ch.tlaun.TL.svg
+++ b/Papirus/16x16/apps/ch.tlaun.TL.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/22x22/apps/ch.tlaun.TL.svg
+++ b/Papirus/22x22/apps/ch.tlaun.TL.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/24x24/apps/ch.tlaun.TL.svg
+++ b/Papirus/24x24/apps/ch.tlaun.TL.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/32x32/apps/ch.tlaun.TL.svg
+++ b/Papirus/32x32/apps/ch.tlaun.TL.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/48x48/apps/ch.tlaun.TL.svg
+++ b/Papirus/48x48/apps/ch.tlaun.TL.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/64x64/apps/ch.tlaun.TL.svg
+++ b/Papirus/64x64/apps/ch.tlaun.TL.svg
@@ -1,0 +1,1 @@
+minecraft.svg


### PR DESCRIPTION
Legacy Launcher is a proprietary Minecraft launcher (previously named TL Legacy) that uses a generic Minecraft icon (a grass block)
They publish it for Linux through Flathub as a `ch.tlaun.TL`.
They also release Ubuntu .debs, but i couldn't find a name it uses in that case. (maybe it's tl-legacy, but i have no way to confirm that)