### PR TITLE
Add symlink for KDE ISO Image Writer

### DIFF
--- a/Papirus/16x16/apps/org.kde.isoimagewriter.svg
+++ b/Papirus/16x16/apps/org.kde.isoimagewriter.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/22x22/apps/org.kde.isoimagewriter.svg
+++ b/Papirus/22x22/apps/org.kde.isoimagewriter.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/24x24/apps/org.kde.isoimagewriter.svg
+++ b/Papirus/24x24/apps/org.kde.isoimagewriter.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/32x32/apps/org.kde.isoimagewriter.svg
+++ b/Papirus/32x32/apps/org.kde.isoimagewriter.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/48x48/apps/org.kde.isoimagewriter.svg
+++ b/Papirus/48x48/apps/org.kde.isoimagewriter.svg
@@ -1,0 +1,1 @@
+usb-creator.svg

--- a/Papirus/64x64/apps/org.kde.isoimagewriter.svg
+++ b/Papirus/64x64/apps/org.kde.isoimagewriter.svg
@@ -1,0 +1,1 @@
+usb-creator.svg


### PR DESCRIPTION
Its icon name is `org.kde.isoimagewriter`

![image](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/941aa892-297e-4eac-9a1a-69fc1f9bddcd)  

Symlinked to usb-creator