### PR TITLE
Add icon for Lagrange

### DIFF
--- a/Papirus/16x16/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/16x16/apps/fi.skyjake.Lagrange.svg
@@ -1,6 +1,6 @@
-<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
- <rect width="16" height="16" rx="3.4285715" ry="3.4285715" style="fill:#1381fd"/>
- <circle cx="5" cy="10" r="4" style="fill:#32c6fd"/>
- <ellipse transform="matrix(.7584808 -.65169539 .54850799 .83614532 0 0)" cx="2.3204443" cy="11.376296" rx="2.5290811" ry="7.4792838" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00426;stroke:#e4e4e4"/>
- <circle cx="12.5" cy="5.5" r="2.5" style="fill:#fecd38"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" version="1.1">
+ <rect style="fill:#1381fd" width="16" height="16" rx="3" ry="3"/>
+ <circle style="fill:#32c6fd" cx="5" cy="10" r="4"/>
+ <ellipse style="fill:none;stroke-width:1.00426;stroke:#e4e4e4" cx="2.32" cy="11.376" rx="2.529" ry="7.479" transform="matrix(.7584808 -.65169539 .54850799 .83614532 0 0)"/>
+ <circle style="fill:#fecd38" cx="12.5" cy="5.5" r="2.5"/>
 </svg>

--- a/Papirus/16x16/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/16x16/apps/fi.skyjake.Lagrange.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect width="16" height="16" rx="3.4285715" ry="3.4285715" style="fill:#1381fd"/>
+ <circle cx="5" cy="10" r="4" style="fill:#32c6fd"/>
+ <ellipse transform="matrix(.7584808 -.65169539 .54850799 .83614532 0 0)" cx="2.3204443" cy="11.376296" rx="2.5290811" ry="7.4792838" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00426;stroke:#e4e4e4"/>
+ <circle cx="12.5" cy="5.5" r="2.5" style="fill:#fecd38"/>
+</svg>

--- a/Papirus/22x22/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/22x22/apps/fi.skyjake.Lagrange.svg
@@ -1,0 +1,13 @@
+<svg width="22" height="22" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="1" y="1.5" width="20" height="20" rx="4" ry="4" style="opacity:.2"/>
+ <rect x="1" y="1" width="20" height="20" rx="4" ry="4" style="fill:#1381fd"/>
+ <path d="m5 1h12c2.216 0 4 1.784 4 4v0.5c0-2.2295569-1.784-4-4-4h-12c-2.216 0-4 1.7704431-4 4v-0.5c0-2.216 1.784-4 4-4z" style="fill:#ffffff;opacity:.2"/>
+ <circle cx="8" cy="13.5" r="5" style="opacity:.2"/>
+ <circle cx="8" cy="13" r="5" style="fill:#32c6fd"/>
+ <path d="m13 13c0-2-2.238577-4.5-5-4.5s-5 2.5-5 4.5c0-2.761423 2.238577-5 5-5s5 2.238577 5 5z" style="fill:#ffffff;opacity:.2"/>
+ <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="3.5530767" cy="16.290941" rx="2.4642191" ry="8.6588564" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00344;stroke:#000000"/>
+ <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="3.8233452" cy="15.900661" rx="2.4642191" ry="8.6588564" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00344;stroke:#e4e4e4"/>
+ <circle cx="16" cy="8.5" r="3" style="fill:#050400;opacity:.2"/>
+ <circle cx="16" cy="8" r="3" style="fill:#fecd38"/>
+ <path d="m19 8c0-1-1.343146-2.5-3-2.5s-3 1.5-3 2.5c0-1.656854 1.343146-3 3-3s3 1.343146 3 3z" style="fill:#fffffe;opacity:.2"/>
+</svg>

--- a/Papirus/22x22/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/22x22/apps/fi.skyjake.Lagrange.svg
@@ -1,13 +1,13 @@
-<svg width="22" height="22" version="1.1" xmlns="http://www.w3.org/2000/svg">
- <rect x="1" y="1.5" width="20" height="20" rx="4" ry="4" style="opacity:.2"/>
- <rect x="1" y="1" width="20" height="20" rx="4" ry="4" style="fill:#1381fd"/>
- <path d="m5 1h12c2.216 0 4 1.784 4 4v0.5c0-2.2295569-1.784-4-4-4h-12c-2.216 0-4 1.7704431-4 4v-0.5c0-2.216 1.784-4 4-4z" style="fill:#ffffff;opacity:.2"/>
- <circle cx="8" cy="13.5" r="5" style="opacity:.2"/>
- <circle cx="8" cy="13" r="5" style="fill:#32c6fd"/>
- <path d="m13 13c0-2-2.238577-4.5-5-4.5s-5 2.5-5 4.5c0-2.761423 2.238577-5 5-5s5 2.238577 5 5z" style="fill:#ffffff;opacity:.2"/>
- <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="3.5530767" cy="16.290941" rx="2.4642191" ry="8.6588564" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00344;stroke:#000000"/>
- <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="3.8233452" cy="15.900661" rx="2.4642191" ry="8.6588564" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00344;stroke:#e4e4e4"/>
- <circle cx="16" cy="8.5" r="3" style="fill:#050400;opacity:.2"/>
- <circle cx="16" cy="8" r="3" style="fill:#fecd38"/>
- <path d="m19 8c0-1-1.343146-2.5-3-2.5s-3 1.5-3 2.5c0-1.656854 1.343146-3 3-3s3 1.343146 3 3z" style="fill:#fffffe;opacity:.2"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" version="1.1">
+ <rect style="opacity:.2" width="20" height="20" x="1" y="1.5" rx="4" ry="4"/>
+ <rect style="fill:#1381fd" width="20" height="20" x="1" y="1" rx="4" ry="4"/>
+ <path style="fill:#ffffff;opacity:.2" d="m5 1h12c2.216 0 4 1.784 4 4v0.5c0-2.2295569-1.784-4-4-4h-12c-2.216 0-4 1.7704431-4 4v-0.5c0-2.216 1.784-4 4-4z"/>
+ <circle style="opacity:.2" cx="8" cy="13.5" r="5"/>
+ <circle style="fill:#32c6fd" cx="8" cy="13" r="5"/>
+ <path style="fill:#ffffff;opacity:.2" d="m13 13c0-2-2.238577-4.5-5-4.5s-5 2.5-5 4.5c0-2.761423 2.238577-5 5-5s5 2.238577 5 5z"/>
+ <ellipse style="fill:none;opacity:.2;stroke-width:1.00344;stroke:#000000" cx="3.553" cy="16.291" rx="2.464" ry="8.659" transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)"/>
+ <ellipse style="fill:none;stroke-width:1.00344;stroke:#e4e4e4" cx="3.823" cy="15.901" rx="2.464" ry="8.659" transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)"/>
+ <circle style="opacity:.2" cx="16" cy="8.5" r="3"/>
+ <circle style="fill:#fecd38" cx="16" cy="8" r="3"/>
+ <path style="fill:#ffffff;opacity:.2" d="m19 8c0-1-1.343146-2.5-3-2.5s-3 1.5-3 2.5c0-1.656854 1.343146-3 3-3s3 1.343146 3 3z"/>
 </svg>

--- a/Papirus/24x24/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/24x24/apps/fi.skyjake.Lagrange.svg
@@ -1,0 +1,13 @@
+<svg width="24" height="24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="2" y="2.5" width="20" height="20" rx="4" ry="4" style="opacity:.2"/>
+ <rect x="2" y="2" width="20" height="20" rx="4" ry="4" style="fill:#1381fd"/>
+ <path d="m6 2h12c2.216 0 4 1.784 4 4v0.5c0-2.2295569-1.784-4-4-4h-12c-2.216 0-4 1.7704431-4 4v-0.5c0-2.216 1.784-4 4-4z" style="fill:#ffffff;opacity:.2"/>
+ <circle cx="9" cy="14.5" r="5" style="opacity:.2"/>
+ <circle cx="9" cy="14" r="5" style="fill:#32c6fd"/>
+ <path d="m14 14c0-2-2.238577-4.5-5-4.5-2.7614235 0-5 2.5-5 4.5 0-2.761423 2.2385765-5 5-5 2.761423 0 5 2.238577 5 5z" style="fill:#ffffff;opacity:.2"/>
+ <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="3.8620391" cy="17.707546" rx="2.4642191" ry="8.6588564" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00344;stroke:#000000"/>
+ <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="4.1323075" cy="17.317266" rx="2.4642191" ry="8.6588564" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00344;stroke:#e4e4e4"/>
+ <circle cx="17" cy="9.5" r="3" style="fill:#050400;opacity:.2"/>
+ <circle cx="17" cy="9" r="3" style="fill:#fecd38"/>
+ <path d="m20 9c0-1-1.343146-2.5-3-2.5s-3 1.5-3 2.5c0-1.656854 1.343146-3 3-3s3 1.343146 3 3z" style="fill:#fffffe;opacity:.2"/>
+</svg>

--- a/Papirus/24x24/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/24x24/apps/fi.skyjake.Lagrange.svg
@@ -1,13 +1,13 @@
-<svg width="24" height="24" version="1.1" xmlns="http://www.w3.org/2000/svg">
- <rect x="2" y="2.5" width="20" height="20" rx="4" ry="4" style="opacity:.2"/>
- <rect x="2" y="2" width="20" height="20" rx="4" ry="4" style="fill:#1381fd"/>
- <path d="m6 2h12c2.216 0 4 1.784 4 4v0.5c0-2.2295569-1.784-4-4-4h-12c-2.216 0-4 1.7704431-4 4v-0.5c0-2.216 1.784-4 4-4z" style="fill:#ffffff;opacity:.2"/>
- <circle cx="9" cy="14.5" r="5" style="opacity:.2"/>
- <circle cx="9" cy="14" r="5" style="fill:#32c6fd"/>
- <path d="m14 14c0-2-2.238577-4.5-5-4.5-2.7614235 0-5 2.5-5 4.5 0-2.761423 2.2385765-5 5-5 2.761423 0 5 2.238577 5 5z" style="fill:#ffffff;opacity:.2"/>
- <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="3.8620391" cy="17.707546" rx="2.4642191" ry="8.6588564" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00344;stroke:#000000"/>
- <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="4.1323075" cy="17.317266" rx="2.4642191" ry="8.6588564" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:1.00344;stroke:#e4e4e4"/>
- <circle cx="17" cy="9.5" r="3" style="fill:#050400;opacity:.2"/>
- <circle cx="17" cy="9" r="3" style="fill:#fecd38"/>
- <path d="m20 9c0-1-1.343146-2.5-3-2.5s-3 1.5-3 2.5c0-1.656854 1.343146-3 3-3s3 1.343146 3 3z" style="fill:#fffffe;opacity:.2"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" version="1.1">
+ <rect style="opacity:.2" width="20" height="20" x="2" y="2.5" rx="4" ry="4"/>
+ <rect style="fill:#1381fd" width="20" height="20" x="2" y="2" rx="4" ry="4"/>
+ <path style="fill:#ffffff;opacity:.2" d="m6 2h12c2.216 0 4 1.784 4 4v0.5c0-2.2295569-1.784-4-4-4h-12c-2.216 0-4 1.7704431-4 4v-0.5c0-2.216 1.784-4 4-4z"/>
+ <circle style="opacity:.2" cx="9" cy="14.5" r="5"/>
+ <circle style="fill:#32c6fd" cx="9" cy="14" r="5"/>
+ <path style="fill:#ffffff;opacity:.2" d="m14 14c0-2-2.238577-4.5-5-4.5-2.7614235 0-5 2.5-5 4.5 0-2.761423 2.2385765-5 5-5 2.761423 0 5 2.238577 5 5z"/>
+ <ellipse style="fill:none;opacity:.2;stroke-width:1.00344;stroke:#000000" cx="3.862" cy="17.708" rx="2.464" ry="8.659" transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)"/>
+ <ellipse style="fill:none;stroke-width:1.00344;stroke:#e4e4e4" cx="4.132" cy="17.317" rx="2.464" ry="8.659" transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)"/>
+ <circle style="opacity:.2" cx="17" cy="9.5" r="3"/>
+ <circle style="fill:#fecd38" cx="17" cy="9" r="3"/>
+ <path style="fill:#ffffff;opacity:.2" d="m20 9c0-1-1.343146-2.5-3-2.5s-3 1.5-3 2.5c0-1.656854 1.343146-3 3-3s3 1.343146 3 3z"/>
 </svg>

--- a/Papirus/32x32/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/32x32/apps/fi.skyjake.Lagrange.svg
@@ -1,0 +1,13 @@
+<svg width="32" height="32" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="2" y="3" width="28" height="28" rx="6" ry="6" style="fill:#000102;opacity:.2"/>
+ <rect x="2" y="2" width="28" height="28" rx="6" ry="6" style="fill:#1381fd"/>
+ <circle cx="11" cy="20" r="7" style="fill:#090909;opacity:.2"/>
+ <circle cx="11" cy="19" r="7" style="fill:#32c6fd"/>
+ <path d="m18 19c0-3-3.134007-6-7-6-3.8659932 0-7 3-7 6 0-3.865993 3.1340068-7 7-7 3.865993 0 7 3.134007 7 7z" style="fill:#ffffff;opacity:.2"/>
+ <ellipse transform="matrix(.73413471 -.67900385 .52038776 .85393008 0 0)" cx="4.913384" cy="23.814819" rx="4.0902047" ry="12.340402" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2.02011;stroke:#000000"/>
+ <ellipse transform="matrix(.73413471 -.67900385 .52038776 .85393008 0 0)" cx="5.4442592" cy="23.065889" rx="4.0902047" ry="12.340402" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2.02011;stroke:#e4e4e4"/>
+ <circle cx="24" cy="13" r="4" style="opacity:.2"/>
+ <circle cx="24" cy="12" r="4" style="fill:#fecd38"/>
+ <path d="m28 12c0-1-1.790861-3-4-3s-4 2-4 3c0-2.209139 1.790861-4 4-4s4 1.790861 4 4z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m8 2h16c3.324 0 6 2.676 6 6v1c0-3-2.676-6-6-6h-16c-3.324 0-6 3-6 6v-1c0-3.324 2.676-6 6-6z" style="fill:#ffffff;opacity:.2"/>
+</svg>

--- a/Papirus/32x32/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/32x32/apps/fi.skyjake.Lagrange.svg
@@ -1,13 +1,13 @@
-<svg width="32" height="32" version="1.1" xmlns="http://www.w3.org/2000/svg">
- <rect x="2" y="3" width="28" height="28" rx="6" ry="6" style="fill:#000102;opacity:.2"/>
- <rect x="2" y="2" width="28" height="28" rx="6" ry="6" style="fill:#1381fd"/>
- <circle cx="11" cy="20" r="7" style="fill:#090909;opacity:.2"/>
- <circle cx="11" cy="19" r="7" style="fill:#32c6fd"/>
- <path d="m18 19c0-3-3.134007-6-7-6-3.8659932 0-7 3-7 6 0-3.865993 3.1340068-7 7-7 3.865993 0 7 3.134007 7 7z" style="fill:#ffffff;opacity:.2"/>
- <ellipse transform="matrix(.73413471 -.67900385 .52038776 .85393008 0 0)" cx="4.913384" cy="23.814819" rx="4.0902047" ry="12.340402" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2.02011;stroke:#000000"/>
- <ellipse transform="matrix(.73413471 -.67900385 .52038776 .85393008 0 0)" cx="5.4442592" cy="23.065889" rx="4.0902047" ry="12.340402" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2.02011;stroke:#e4e4e4"/>
- <circle cx="24" cy="13" r="4" style="opacity:.2"/>
- <circle cx="24" cy="12" r="4" style="fill:#fecd38"/>
- <path d="m28 12c0-1-1.790861-3-4-3s-4 2-4 3c0-2.209139 1.790861-4 4-4s4 1.790861 4 4z" style="fill:#ffffff;opacity:.2"/>
- <path d="m8 2h16c3.324 0 6 2.676 6 6v1c0-3-2.676-6-6-6h-16c-3.324 0-6 3-6 6v-1c0-3.324 2.676-6 6-6z" style="fill:#ffffff;opacity:.2"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" version="1.1">
+ <rect style="opacity:.2" width="28" height="28" x="2" y="3" rx="6" ry="6"/>
+ <rect style="fill:#1381fd" width="28" height="28" x="2" y="2" rx="6" ry="6"/>
+ <circle style="opacity:.2" cx="11" cy="20" r="7"/>
+ <circle style="fill:#32c6fd" cx="11" cy="19" r="7"/>
+ <path style="fill:#ffffff;opacity:.2" d="m18 19c0-3-3.134007-6-7-6-3.8659932 0-7 3-7 6 0-3.865993 3.1340068-7 7-7 3.865993 0 7 3.134007 7 7z"/>
+ <ellipse style="fill:none;opacity:.2;stroke-width:2.02011;stroke:#000000" cx="4.913" cy="23.815" rx="4.09" ry="12.34" transform="matrix(.73413471 -.67900385 .52038776 .85393008 0 0)"/>
+ <ellipse style="fill:none;stroke-width:2.02011;stroke:#e4e4e4" cx="5.444" cy="23.066" rx="4.09" ry="12.34" transform="matrix(.73413471 -.67900385 .52038776 .85393008 0 0)"/>
+ <circle style="opacity:.2" cx="24" cy="13" r="4"/>
+ <circle style="fill:#fecd38" cx="24" cy="12" r="4"/>
+ <path style="fill:#ffffff;opacity:.2" d="m28 12c0-1-1.790861-3-4-3s-4 2-4 3c0-2.209139 1.790861-4 4-4s4 1.790861 4 4z"/>
+ <path style="fill:#ffffff;opacity:.2" d="m8 2h16c3.324 0 6 2.676 6 6v1c0-3-2.676-6-6-6h-16c-3.324 0-6 3-6 6v-1c0-3.324 2.676-6 6-6z"/>
 </svg>

--- a/Papirus/48x48/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/48x48/apps/fi.skyjake.Lagrange.svg
@@ -1,0 +1,13 @@
+<svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="4" y="5" width="40" height="40" rx="8" ry="8" style="opacity:.2"/>
+ <rect x="4" y="4" width="40" height="40" rx="8" ry="8" style="fill:#1381fd"/>
+ <path d="m12 4h24c4.432 0 8 3.568 8 8v1c0-4.4591139-3.568-8-8-8h-24c-4.432 0-8 3.5408861-8 8v-1c0-4.432 3.568-8 8-8z" style="fill:#ffffff;opacity:.2"/>
+ <circle cx="18" cy="29" r="10" style="opacity:.2"/>
+ <circle cx="18" cy="28" r="10" style="fill:#32c6fd"/>
+ <path d="m28 28c0-4-4.477153-9-10-9s-10 5-10 9c0-5.522847 4.477153-10 10-10s10 4.477153 10 10z" style="fill:#ffffff;opacity:.2"/>
+ <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="7.7240782" cy="35.415092" rx="4.9284382" ry="17.317713" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2.00672;stroke:#000000"/>
+ <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="8.2646151" cy="34.634533" rx="4.9284382" ry="17.317713" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2.00672;stroke:#e4e4e4"/>
+ <circle cx="34" cy="19" r="6" style="fill:#050400;opacity:.2"/>
+ <circle cx="34" cy="18" r="6" style="fill:#fecd38"/>
+ <path d="m40 18c0-2-2.686292-5-6-5s-6 3-6 5c0-3.313708 2.686292-6 6-6s6 2.686292 6 6z" style="fill:#fffffe;opacity:.2"/>
+</svg>

--- a/Papirus/48x48/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/48x48/apps/fi.skyjake.Lagrange.svg
@@ -1,13 +1,13 @@
-<svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg">
- <rect x="4" y="5" width="40" height="40" rx="8" ry="8" style="opacity:.2"/>
- <rect x="4" y="4" width="40" height="40" rx="8" ry="8" style="fill:#1381fd"/>
- <path d="m12 4h24c4.432 0 8 3.568 8 8v1c0-4.4591139-3.568-8-8-8h-24c-4.432 0-8 3.5408861-8 8v-1c0-4.432 3.568-8 8-8z" style="fill:#ffffff;opacity:.2"/>
- <circle cx="18" cy="29" r="10" style="opacity:.2"/>
- <circle cx="18" cy="28" r="10" style="fill:#32c6fd"/>
- <path d="m28 28c0-4-4.477153-9-10-9s-10 5-10 9c0-5.522847 4.477153-10 10-10s10 4.477153 10 10z" style="fill:#ffffff;opacity:.2"/>
- <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="7.7240782" cy="35.415092" rx="4.9284382" ry="17.317713" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2.00672;stroke:#000000"/>
- <ellipse transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)" cx="8.2646151" cy="34.634533" rx="4.9284382" ry="17.317713" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2.00672;stroke:#e4e4e4"/>
- <circle cx="34" cy="19" r="6" style="fill:#050400;opacity:.2"/>
- <circle cx="34" cy="18" r="6" style="fill:#fecd38"/>
- <path d="m40 18c0-2-2.686292-5-6-5s-6 3-6 5c0-3.313708 2.686292-6 6-6s6 2.686292 6 6z" style="fill:#fffffe;opacity:.2"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" version="1.1">
+ <rect style="opacity:.2" width="40" height="40" x="4" y="5" rx="8" ry="8"/>
+ <rect style="fill:#1381fd" width="40" height="40" x="4" y="4" rx="8" ry="8"/>
+ <path style="fill:#ffffff;opacity:.2" d="m12 4h24c4.432 0 8 3.568 8 8v1c0-4.4591139-3.568-8-8-8h-24c-4.432 0-8 3.5408861-8 8v-1c0-4.432 3.568-8 8-8z"/>
+ <circle style="opacity:.2" cx="18" cy="29" r="10"/>
+ <circle style="fill:#32c6fd" cx="18" cy="28" r="10"/>
+ <path style="fill:#ffffff;opacity:.2" d="m28 28c0-4-4.477153-9-10-9s-10 5-10 9c0-5.522847 4.477153-10 10-10s10 4.477153 10 10z"/>
+ <ellipse style="fill:none;opacity:.2;stroke-width:2.00672;stroke:#000000" cx="7.724" cy="35.415" rx="4.928" ry="17.318" transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)"/>
+ <ellipse style="fill:none;stroke-width:2.00672;stroke:#e4e4e4" cx="8.265" cy="34.635" rx="4.928" ry="17.318" transform="matrix(.77521865 -.631693 .53683743 .84368571 0 0)"/>
+ <circle style="opacity:.2" cx="34" cy="19" r="6"/>
+ <circle style="fill:#fecd38" cx="34" cy="18" r="6"/>
+ <path style="fill:#ffffff;opacity:.2" d="m40 18c0-2-2.686292-5-6-5s-6 3-6 5c0-3.313708 2.686292-6 6-6s6 2.686292 6 6z"/>
 </svg>

--- a/Papirus/64x64/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/64x64/apps/fi.skyjake.Lagrange.svg
@@ -1,0 +1,13 @@
+<svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="4" y="5" width="56" height="56" rx="12" ry="12" style="fill:#000102;opacity:.2"/>
+ <rect x="4" y="4" width="56" height="56" rx="12" ry="12" style="fill:#1381fd"/>
+ <circle cx="22" cy="39" r="14" style="fill:#090909;opacity:.2"/>
+ <circle cx="22" cy="38" r="14" style="fill:#32c6fd"/>
+ <path d="m36 38c0-7-6.268014-13-14-13s-14 6-14 13c0-7.731986 6.268014-14 14-14s14 6.268014 14 14z" style="fill:#ffffff;opacity:.2"/>
+ <ellipse transform="matrix(.73621084 -.67675224 .52272112 .85250374 0 0)" cx="11.089157" cy="47.512741" rx="8.4164562" ry="25.351112" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:3.02868;stroke:#000000"/>
+ <ellipse transform="matrix(.73621084 -.67675224 .52272112 .85250374 0 0)" cx="11.621799" cy="46.762558" rx="8.4164562" ry="25.351112" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:3.02868;stroke:#e4e4e4"/>
+ <circle cx="48" cy="25" r="8" style="opacity:.2"/>
+ <circle cx="48" cy="24" r="8" style="fill:#fecd38"/>
+ <path d="m56 24c0-3-3.581722-7-8-7s-8 4-8 7c0-4.418278 3.581722-8 8-8s8 3.581722 8 8z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m16 4h32c6.648 0 12 5.352 12 12v1c0-6-5.352-12-12-12h-32c-6.648 0-12 6-12 12v-1c0-6.648 5.352-12 12-12z" style="fill:#ffffff;opacity:.2"/>
+</svg>

--- a/Papirus/64x64/apps/fi.skyjake.Lagrange.svg
+++ b/Papirus/64x64/apps/fi.skyjake.Lagrange.svg
@@ -1,13 +1,13 @@
-<svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
- <rect x="4" y="5" width="56" height="56" rx="12" ry="12" style="fill:#000102;opacity:.2"/>
- <rect x="4" y="4" width="56" height="56" rx="12" ry="12" style="fill:#1381fd"/>
- <circle cx="22" cy="39" r="14" style="fill:#090909;opacity:.2"/>
- <circle cx="22" cy="38" r="14" style="fill:#32c6fd"/>
- <path d="m36 38c0-7-6.268014-13-14-13s-14 6-14 13c0-7.731986 6.268014-14 14-14s14 6.268014 14 14z" style="fill:#ffffff;opacity:.2"/>
- <ellipse transform="matrix(.73621084 -.67675224 .52272112 .85250374 0 0)" cx="11.089157" cy="47.512741" rx="8.4164562" ry="25.351112" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:3.02868;stroke:#000000"/>
- <ellipse transform="matrix(.73621084 -.67675224 .52272112 .85250374 0 0)" cx="11.621799" cy="46.762558" rx="8.4164562" ry="25.351112" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:3.02868;stroke:#e4e4e4"/>
- <circle cx="48" cy="25" r="8" style="opacity:.2"/>
- <circle cx="48" cy="24" r="8" style="fill:#fecd38"/>
- <path d="m56 24c0-3-3.581722-7-8-7s-8 4-8 7c0-4.418278 3.581722-8 8-8s8 3.581722 8 8z" style="fill:#ffffff;opacity:.2"/>
- <path d="m16 4h32c6.648 0 12 5.352 12 12v1c0-6-5.352-12-12-12h-32c-6.648 0-12 6-12 12v-1c0-6.648 5.352-12 12-12z" style="fill:#ffffff;opacity:.2"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" version="1.1">
+ <rect style="opacity:.2" width="56" height="56" x="4" y="5" rx="12" ry="12"/>
+ <rect style="fill:#1381fd" width="56" height="56" x="4" y="4" rx="12" ry="12"/>
+ <circle style="opacity:.2" cx="22" cy="39" r="14"/>
+ <circle style="fill:#32c6fd" cx="22" cy="38" r="14"/>
+ <path style="fill:#ffffff;opacity:.2" d="m36 38c0-7-6.268014-13-14-13s-14 6-14 13c0-7.731986 6.268014-14 14-14s14 6.268014 14 14z"/>
+ <ellipse style="fill:none;opacity:.2;stroke-width:3.02868;stroke:#000000" cx="11.089" cy="47.513" rx="8.416" ry="25.351" transform="matrix(.73621084 -.67675224 .52272112 .85250374 0 0)"/>
+ <ellipse style="fill:none;stroke-width:3.02868;stroke:#e4e4e4" cx="11.622" cy="46.763" rx="8.416" ry="25.351" transform="matrix(.73621084 -.67675224 .52272112 .85250374 0 0)"/>
+ <circle style="opacity:.2" cx="48" cy="25" r="8"/>
+ <circle style="fill:#fecd38" cx="48" cy="24" r="8"/>
+ <path style="fill:#ffffff;opacity:.2" d="m56 24c0-3-3.581722-7-8-7s-8 4-8 7c0-4.418278 3.581722-8 8-8s8 3.581722 8 8z"/>
+ <path style="fill:#ffffff;opacity:.2" d="m16 4h32c6.648 0 12 5.352 12 12v1c0-6-5.352-12-12-12h-32c-6.648 0-12 6-12 12v-1c0-6.648 5.352-12 12-12z"/>
 </svg>


### PR DESCRIPTION
[Lagrange](https://gmi.skyjake.fi/lagrange/) is a cross-platform desktop GUI client for browsing [Geminispace](https://gemini.circumlunar.space/).

Papirus icons:  

![fi skyjake Lagrange@64x64](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/c6ba1471-3baf-495c-b049-201198485a86) ![fi skyjake Lagrange@48x48](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/c6ed6479-9f79-4cd5-aa8a-3a6dff4142cd) ![fi skyjake Lagrange@32x32](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/738ad2ca-e051-41d3-a335-ed005a55def6)  ![fi skyjake Lagrange@16x16](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/a5c9dcb2-2e7e-41c8-a646-7a74bcb3346c)  

Original icon:  

![fi skyjake Lagrange](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/2e1018e3-dbef-4e5f-a221-1b739d4c7658)
