### PR TITLE
Add symlink for OpenMW Content Editor

### DIFF
--- a/Papirus/16x16/apps/org.openmw.OpenMW.OpenCS.svg
+++ b/Papirus/16x16/apps/org.openmw.OpenMW.OpenCS.svg
@@ -1,0 +1,1 @@
+openmw-cs.svg

--- a/Papirus/22x22/apps/org.openmw.OpenMW.OpenCS.svg
+++ b/Papirus/22x22/apps/org.openmw.OpenMW.OpenCS.svg
@@ -1,0 +1,1 @@
+openmw-cs.svg

--- a/Papirus/24x24/apps/org.openmw.OpenMW.OpenCS.svg
+++ b/Papirus/24x24/apps/org.openmw.OpenMW.OpenCS.svg
@@ -1,0 +1,1 @@
+openmw-cs.svg

--- a/Papirus/32x32/apps/org.openmw.OpenMW.OpenCS.svg
+++ b/Papirus/32x32/apps/org.openmw.OpenMW.OpenCS.svg
@@ -1,0 +1,1 @@
+openmw-cs.svg

--- a/Papirus/48x48/apps/org.openmw.OpenMW.OpenCS.svg
+++ b/Papirus/48x48/apps/org.openmw.OpenMW.OpenCS.svg
@@ -1,0 +1,1 @@
+openmw-cs.svg

--- a/Papirus/64x64/apps/org.openmw.OpenMW.OpenCS.svg
+++ b/Papirus/64x64/apps/org.openmw.OpenMW.OpenCS.svg
@@ -1,0 +1,1 @@
+openmw-cs.svg


### PR DESCRIPTION
There was already a symlink for OpenMW flatpak, but the symlink for OpenMW Content Editor (the second application inside a single flatpak) wasn't made for five years.