### PR TITLE
added AUR srb2kart, Vinegar symlinks

### DIFF
--- a/Papirus/16x16/apps/io.github.vinegarhq.Vinegar.player.svg
+++ b/Papirus/16x16/apps/io.github.vinegarhq.Vinegar.player.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-player.svg

--- a/Papirus/16x16/apps/io.github.vinegarhq.Vinegar.studio.svg
+++ b/Papirus/16x16/apps/io.github.vinegarhq.Vinegar.studio.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-studio.svg

--- a/Papirus/16x16/apps/srb2kart.svg
+++ b/Papirus/16x16/apps/srb2kart.svg
@@ -1,0 +1,1 @@
+org.srb2.SRB2Kart.svg

--- a/Papirus/22x22/apps/io.github.vinegarhq.Vinegar.player.svg
+++ b/Papirus/22x22/apps/io.github.vinegarhq.Vinegar.player.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-player.svg

--- a/Papirus/22x22/apps/io.github.vinegarhq.Vinegar.studio.svg
+++ b/Papirus/22x22/apps/io.github.vinegarhq.Vinegar.studio.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-studio.svg

--- a/Papirus/22x22/apps/srb2kart.svg
+++ b/Papirus/22x22/apps/srb2kart.svg
@@ -1,0 +1,1 @@
+org.srb2.SRB2Kart.svg

--- a/Papirus/24x24/apps/io.github.vinegarhq.Vinegar.player.svg
+++ b/Papirus/24x24/apps/io.github.vinegarhq.Vinegar.player.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-player.svg

--- a/Papirus/24x24/apps/io.github.vinegarhq.Vinegar.studio.svg
+++ b/Papirus/24x24/apps/io.github.vinegarhq.Vinegar.studio.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-studio.svg

--- a/Papirus/24x24/apps/srb2kart.svg
+++ b/Papirus/24x24/apps/srb2kart.svg
@@ -1,0 +1,1 @@
+org.srb2.SRB2Kart.svg

--- a/Papirus/32x32/apps/io.github.vinegarhq.Vinegar.player.svg
+++ b/Papirus/32x32/apps/io.github.vinegarhq.Vinegar.player.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-player.svg

--- a/Papirus/32x32/apps/io.github.vinegarhq.Vinegar.studio.svg
+++ b/Papirus/32x32/apps/io.github.vinegarhq.Vinegar.studio.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-studio.svg

--- a/Papirus/32x32/apps/srb2kart.svg
+++ b/Papirus/32x32/apps/srb2kart.svg
@@ -1,0 +1,1 @@
+org.srb2.SRB2Kart.svg

--- a/Papirus/48x48/apps/io.github.vinegarhq.Vinegar.player.svg
+++ b/Papirus/48x48/apps/io.github.vinegarhq.Vinegar.player.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-player.svg

--- a/Papirus/48x48/apps/io.github.vinegarhq.Vinegar.studio.svg
+++ b/Papirus/48x48/apps/io.github.vinegarhq.Vinegar.studio.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-studio.svg

--- a/Papirus/48x48/apps/srb2kart.svg
+++ b/Papirus/48x48/apps/srb2kart.svg
@@ -1,0 +1,1 @@
+org.srb2.SRB2Kart.svg

--- a/Papirus/64x64/apps/io.github.vinegarhq.Vinegar.player.svg
+++ b/Papirus/64x64/apps/io.github.vinegarhq.Vinegar.player.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-player.svg

--- a/Papirus/64x64/apps/io.github.vinegarhq.Vinegar.studio.svg
+++ b/Papirus/64x64/apps/io.github.vinegarhq.Vinegar.studio.svg
@@ -1,0 +1,1 @@
+grapejuice-roblox-studio.svg

--- a/Papirus/64x64/apps/srb2kart.svg
+++ b/Papirus/64x64/apps/srb2kart.svg
@@ -1,0 +1,1 @@
+org.srb2.SRB2Kart.svg


### PR DESCRIPTION
The SRB2Kart AUR package asks for an `srb2kart` icon that doesn't exist. So i symlinked it with the original flatpak naming scheme icon.

Another Roblox launcher called Vinegar appeared recently, and it also uses the Roblox and Roblox Studio icons for its launchers (at least on AUR, couldn't find any icons for the flatpak version, might be the same ones), so I symlinked them with Grapejuice's player and studio icons respectively.

![Screenshot_20230822_211337](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/53501005/eea9d724-eaf4-4072-9998-8f3f6635e0c6)

