### PR TITLE
Add icon for Gradience

### DIFF
--- a/Papirus/16x16/apps/com.github.GradienceTeam.Gradience.svg
+++ b/Papirus/16x16/apps/com.github.GradienceTeam.Gradience.svg
@@ -1,0 +1,17 @@
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect y="2" width="16" height="12" ry="2" style="fill:#e4e4e4"/>
+ <path d="m6.5 11.5v-1h7v-4h-1" style="fill:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke:#afafb1"/>
+ <rect x="5" y="11" width="3" height="5" ry="1" style="fill:#4f4f4f"/>
+ <path d="m2 2h1v3h-3v-1c0-1.1953125 0.8046875-2 2-2z" style="fill:#50beee"/>
+ <rect x="3" y="2" width="3" height="3" style="fill:#79de7d"/>
+ <rect x="6" y="2" width="3" height="3" style="fill:#fed65c"/>
+ <rect x="9" y="2" width="3" height="3" style="fill:#df574d"/>
+ <g transform="matrix(1,0,0,1.25,0,-2.25)">
+  <path d="m9 5h2c0.503906 0 1 0.4 1 0.8v2.4c0 0.396875-0.503906 0.8-1 0.8h-2z" style="fill:#e14134"/>
+  <rect x="6" y="5" width="3" height="4" style="fill:#fecd38"/>
+  <rect x="3" y="5" width="3" height="4" style="fill:#4ec353"/>
+  <path d="m0 5.8c0-0.396875 0.49609375-0.8 1-0.8h2v4h-2c-0.5 0-1-0.4-1-0.8z" style="fill:#2aa0ea"/>
+ </g>
+ <circle cx="6.5" cy="14.5" r=".5" style="opacity:.2"/>
+ <circle cx="14" cy="4" r="1" style="opacity:.2"/>
+</svg>

--- a/Papirus/22x22/apps/com.github.GradienceTeam.Gradience.svg
+++ b/Papirus/22x22/apps/com.github.GradienceTeam.Gradience.svg
@@ -1,0 +1,27 @@
+<svg width="22" height="22" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="2" y="3.5" width="18" height="16" rx="2" ry="2" style="opacity:.2"/>
+ <rect x="2" y="3" width="18" height="16" rx="2" ry="2" style="fill:#e4e4e4"/>
+ <path d="m14 3h4c1.107275 0 2 0.8949001 2 2v2h-6z" style="opacity:.1"/>
+ <g transform="matrix(.5 0 0 .5 -1 -1)">
+  <path d="m10 8h2v8h-6v-4c0-2.2190238 1.7596996-4 4-4z" style="fill:#50beee"/>
+  <rect x="12" y="8" width="6" height="8" style="fill:#79de7d"/>
+  <rect x="18" y="8" width="6" height="8" style="fill:#fed65c"/>
+  <rect x="24" y="8" width="6" height="8" style="fill:#df574d"/>
+ </g>
+ <rect x="1" y="7.5" width="13.999998" height="5" ry=".99976277" style="opacity:.1"/>
+ <g transform="matrix(.5 0 0 .5 -1 -1)">
+  <path d="m4 18c0-1 1-2 2-2h6v10h-6c-0.9919313 0-2-0.990247-2-2z" style="fill:#2aa0ea"/>
+  <rect x="12" y="16" width="6" height="10" style="fill:#4ec353"/>
+  <rect x="18" y="16" width="6" height="10" style="fill:#fecd38"/>
+  <path d="m24 16h6c1 0 2 1 2 2v6c0 1.005397-0.998572 2-2 2h-6z" style="fill:#e14134"/>
+ </g>
+ <path d="m8.5 15v-1h8v-4h-1" style="fill:none;opacity:.1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke:#000000"/>
+ <path d="m8.5 14.5v-1h8v-4h-1" style="fill:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke:#afafb1"/>
+ <rect x="7" y="15.5" width="3" height="6" ry="1" style="opacity:.2"/>
+ <rect x="7" y="15" width="3" height="6" ry="1" style="fill:#4f4f4f"/>
+ <circle cx="8.5" cy="19.5" r=".5" style="opacity:.2"/>
+ <path d="m7 16c0-0.55816 0.441406-1 1-1h1c0.554688 0 1 0.433594 1 1v0.5c0-0.5625-0.431933-1-1-1h-1c-0.564453-0.0039-1 0.441406-1 1z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m1 8c0-0.501123 0.4965266-1 1-1h12c0.496575 0 1 0.5037295 1 1v0.5c0-0.5-0.503881-1-1-1h-12c-0.4981634 0-1 0.5-1 1z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m2 5c0-1.1270583 0.9117185-2 2-2h14c1.09933 0 2 0.8951457 2 2v0.5c0-1.1159165-0.90067-2-2-2h-14c-1.0827572 0-2 0.9006145-2 2z" style="fill:#ffffff;opacity:.2"/>
+ <circle cx="18" cy="5" r="1" style="opacity:.2"/>
+</svg>

--- a/Papirus/24x24/apps/com.github.GradienceTeam.Gradience.svg
+++ b/Papirus/24x24/apps/com.github.GradienceTeam.Gradience.svg
@@ -1,0 +1,27 @@
+<svg width="24" height="24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="3" y="3.5" width="18" height="16" rx="2" ry="2" style="opacity:.2"/>
+ <rect x="3" y="3" width="18" height="16" rx="2" ry="2" style="fill:#e4e4e4"/>
+ <path d="m15 3h4c1.107275 0 2 0.8949001 2 2v2h-6z" style="opacity:.1"/>
+ <g transform="matrix(.5 0 0 .5 0 -1)">
+  <path d="m10 8h2v8h-6v-4c0-2.2190238 1.7596996-4 4-4z" style="fill:#50beee"/>
+  <rect x="12" y="8" width="6" height="8" style="fill:#79de7d"/>
+  <rect x="18" y="8" width="6" height="8" style="fill:#fed65c"/>
+  <rect x="24" y="8" width="6" height="8" style="fill:#df574d"/>
+ </g>
+ <rect x="2" y="7.5" width="13.999998" height="5" ry=".99976277" style="opacity:.1"/>
+ <g transform="matrix(.5 0 0 .5 0 -1)">
+  <path d="m4 18c0-1 1-2 2-2h6v10h-6c-0.9919313 0-2-0.990247-2-2z" style="fill:#2aa0ea"/>
+  <rect x="12" y="16" width="6" height="10" style="fill:#4ec353"/>
+  <rect x="18" y="16" width="6" height="10" style="fill:#fecd38"/>
+  <path d="m24 16h6c1 0 2 1 2 2v6c0 1.005397-0.998572 2-2 2h-6z" style="fill:#e14134"/>
+ </g>
+ <path d="m9.5 15v-1h8v-4h-1" style="fill:none;opacity:.1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke:#000000"/>
+ <path d="m9.5 14.5v-1h8v-4h-1" style="fill:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke:#afafb1"/>
+ <rect x="8" y="15.5" width="3" height="6" ry="1" style="opacity:.2"/>
+ <rect x="8" y="15" width="3" height="6" ry="1" style="fill:#4f4f4f"/>
+ <circle cx="9.5" cy="19.5" r=".5" style="opacity:.2"/>
+ <path d="m8 16c0-0.55816 0.441406-1 1-1h1c0.554688 0 1 0.433594 1 1v0.5c0-0.5625-0.431933-1-1-1h-1c-0.564453-0.0039-1 0.441406-1 1z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m2 8c0-0.501123 0.4965266-1 1-1h12c0.496575 0 1 0.5037295 1 1v0.5c0-0.5-0.503881-1-1-1h-12c-0.4981634 0-1 0.5-1 1z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m3 5c0-1.1270583 0.9117185-2 2-2h14c1.09933 0 2 0.8951457 2 2v0.5c0-1.1159165-0.90067-2-2-2h-14c-1.0827572 0-2 0.9006145-2 2z" style="fill:#ffffff;opacity:.2"/>
+ <circle cx="19" cy="5" r="1" style="opacity:.2"/>
+</svg>

--- a/Papirus/32x32/apps/com.github.GradienceTeam.Gradience.svg
+++ b/Papirus/32x32/apps/com.github.GradienceTeam.Gradience.svg
@@ -1,0 +1,25 @@
+<svg width="32" height="32" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="3" y="6" width="26" height="22" rx="3" ry="3" style="opacity:.2"/>
+ <rect x="2.9921875" y="5" width="26" height="22" rx="3" ry="3" style="fill:#e4e4e4"/>
+ <rect x="2" y="12" width="18" height="7" ry="1" style="opacity:.1"/>
+ <path d="m19 5h7c1.639549 0 3 1.350438 3 3v3h-10z" style="opacity:.1"/>
+ <path d="m20.5 15.5h1v6h-10v1" style="fill:none;opacity:.1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke:#000000"/>
+ <path d="m20.5 14.5h1v6h-10v1" style="fill:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke:#afafb1"/>
+ <rect x="10" y="23" width="3" height="8" ry="1" style="opacity:.2"/>
+ <rect x="10" y="22" width="3" height="8" ry="1" style="fill:#4f4f4f"/>
+ <circle cx="11.5" cy="28.5" r=".5" style="opacity:.2"/>
+ <path d="m6 5h1v6h-4v-3c0-1.6850204 1.3398361-3 3-3z" style="fill:#50beee"/>
+ <rect x="7" y="5" width="4" height="6" style="fill:#79de7d"/>
+ <rect x="11" y="5" width="4" height="6" style="fill:#fed65c"/>
+ <rect x="15" y="5" width="4" height="6" style="fill:#df574d"/>
+ <g transform="translate(0,6)">
+  <path d="m2 6c0-0.497707 0.4993742-1 1-1h4v7h-4c-0.4999071 0-1-0.502786-1-1z" style="fill:#2aa0ea"/>
+  <rect x="7" y="5" width="4" height="7" style="fill:#4ec353"/>
+  <rect x="11" y="5" width="4" height="7" style="fill:#fecd38"/>
+  <path d="m15 5h4c0.501614 0 1 0.5027867 1 1v5c0 0.502107-0.500587 1-1 1h-4z" style="fill:#e14134"/>
+ </g>
+ <path d="m2 12c0-0.500514 0.4960742-1 1-1h16c0.502713 0 1 0.501687 1 1v1c0-0.503319-0.501193-1-1-1h-16c-0.5006258 0-1 0.498274-1 1z" style="fill:#fffefe;opacity:.2"/>
+ <path d="m3 8v1c0-1.6712293 1.3220595-3 3-3h20c1.670861 0 3 1.3220595 3 3v-1c0-1.6708606-1.343299-3-3-3h-20c-1.6779405 0-3 1.3115164-3 3z" style="fill:#fffefe;opacity:.2"/>
+ <path d="m10 23c0-0.555695 0.443269-1 1-1h1c0.556731 0 1 0.439817 1 1v1c0-0.556212-0.437745-1-1-1h-1c-0.55138 0-1 0.436709-1 1z" style="fill:#fffefe;opacity:.2"/>
+ <circle cx="25.5" cy="8.5" r="1.5" style="opacity:.2"/>
+</svg>

--- a/Papirus/48x48/apps/com.github.GradienceTeam.Gradience.svg
+++ b/Papirus/48x48/apps/com.github.GradienceTeam.Gradience.svg
@@ -1,0 +1,23 @@
+<svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="6" y="9" width="36" height="32" rx="4" ry="4" style="opacity:.2"/>
+ <rect x="6" y="8" width="36" height="32" rx="4" ry="4" style="fill:#e4e4e4"/>
+ <path d="m30 8h8c2.237797 0 4 1.7922403 4 4v4h-12z" style="opacity:.1"/>
+ <circle cx="37.5" cy="12.5" r="2.5" style="opacity:.2"/>
+ <path d="m10 8h2v8h-6v-4c0-2.2190238 1.7596996-4 4-4z" style="fill:#50beee"/>
+ <rect x="12" y="8" width="6" height="8" style="fill:#79de7d"/>
+ <rect x="18" y="8" width="6" height="8" style="fill:#fed65c"/>
+ <rect x="24" y="8" width="6" height="8" style="fill:#df574d"/>
+ <rect x="5" y="17" width="26" height="10" rx="1" ry="1.25" style="opacity:.1"/>
+ <path d="m5 17c0-0.540676 0.4443054-1 1-1h6v10h-6c-0.5309938 0-1-0.490246-1-1z" style="fill:#2aa0ea"/>
+ <rect x="12" y="16" width="6" height="10" style="fill:#4ec353"/>
+ <rect x="18" y="16" width="6" height="10" style="fill:#fecd38"/>
+ <path d="m24 16h6c0.555695 0 1 0.399249 1 1v8c0 0.570713-0.444305 1-1 1h-6z" style="fill:#e14134"/>
+ <path d="m18 32v-2h16v-8h-2" style="fill:none;opacity:.1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2;stroke:#000000"/>
+ <path d="m18 31v-2h16v-8h-2" style="fill:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2;stroke:#afafb1"/>
+ <rect x="16" y="33" width="4" height="12" rx="1" ry="1.2" style="opacity:.2"/>
+ <rect x="16" y="32" width="4" height="12" rx="1" ry="1" style="fill:#4f4f4f"/>
+ <circle cx="18" cy="42" r="1" style="opacity:.2"/>
+ <path d="m5 17c0-0.525684 0.4383658-1 1-1h24c0.594713 0 1 0.437147 1 1v1c0-0.584093-0.453076-1-1-1h-24c-0.4885143 0-1 0.474316-1 1z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m16 33c0-0.546009 0.4375-1 1-1h2c0.554687 0 1 0.429687 1 1v1c0-0.539063-0.464844-1-1-1h-2c-0.550781 0-1 0.460937-1 1z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m6 12c0-2.2541165 1.8234369-4 4-4h28c2.19866 0 4 1.7902913 4 4v1c0-2.231833-1.80134-4-4-4h-28c-2.1655145 0-4 1.801229-4 4z" style="fill:#ffffff;opacity:.2"/>
+</svg>

--- a/Papirus/64x64/apps/com.github.GradienceTeam.Gradience.svg
+++ b/Papirus/64x64/apps/com.github.GradienceTeam.Gradience.svg
@@ -1,0 +1,27 @@
+<svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <rect x="6" y="11" width="52" height="44" rx="6" ry="6" style="opacity:.2"/>
+ <rect x="6" y="10" width="52" height="44" rx="6" ry="6" style="fill:#e4e4e4"/>
+ <path d="m40 29h3v11h-21v2" style="fill:none;opacity:.1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2;stroke:#000000"/>
+ <path d="m40 28h3v11h-21v4" style="fill:none;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-width:2;stroke:#afafb1"/>
+ <rect x="19" y="45" width="6" height="16" ry="1" style="opacity:.2"/>
+ <rect x="19" y="44" width="6" height="16" ry="1" style="fill:#4f4f4f"/>
+ <circle cx="22" cy="58" r="1" style="opacity:.2"/>
+ <g transform="scale(2)">
+  <path d="m6 5h1v6h-4v-3c0-1.6850204 1.3398361-3 3-3z" style="fill:#50beee"/>
+  <rect x="7" y="5" width="4" height="6" style="fill:#79de7d"/>
+  <rect x="11" y="5" width="4" height="6" style="fill:#fed65c"/>
+  <rect x="15" y="5" width="4" height="6" style="fill:#df574d"/>
+ </g>
+ <rect x="5" y="22" width="34" height="14" ry="1" style="opacity:.1"/>
+ <g transform="matrix(2,0,0,2,0,12)">
+  <path d="m2.5 5c0-0.2503992 0.252196-0.5 0.5-0.5h4v7h-4c-0.242712 0-0.5-0.251926-0.5-0.5z" style="fill:#2aa0ea"/>
+  <rect x="7" y="4.5" width="4" height="7" style="fill:#4ec353"/>
+  <rect x="11" y="4.5" width="4" height="7" style="fill:#fecd38"/>
+  <path d="m15 4.5h4c0.250313 0 0.5 0.2496871 0.5 0.5v6c0 0.250313-0.249687 0.5-0.5 0.5h-4z" style="fill:#e14134"/>
+ </g>
+ <path d="m5 22c0-0.500627 0.4993743-1 1-1h32c0.500626 0 1 0.499374 1 1v1c0-0.500625-0.499374-1-1-1h-32c-0.5006258 0-1 0.499378-1 1z" style="fill:#fffefe;opacity:.2"/>
+ <path d="m6 16v1c0-3.342459 2.644119-6 6-6h40c3.341722 0 6 2.644119 6 6v-1c0-3.341721-2.686598-6-6-6h-40c-3.355881 0-6 2.623033-6 6z" style="fill:#fffefe;opacity:.2"/>
+ <path d="m19 45c0-0.564516 0.439886-1 1-1h4c0.560114 0 1 0.438892 1 1v1c0-0.562314-0.43989-1-1-1h-4c-0.559351 0-1 0.436472-1 1z" style="fill:#fffefe;opacity:.2"/>
+ <path d="m38 10h14c3.328627 0 6 2.671375 6 6v5h-20z" style="opacity:.1"/>
+ <circle cx="52" cy="16" r="3" style="opacity:.2"/>
+</svg>


### PR DESCRIPTION
closes #3275  

I decided against using a libadwaita close button and went with more simplified header bar instead. This way it won't be rendered  in a strange way.

![Gradience@64x64](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/fd72ba49-ef87-4a4b-839c-22b81c9ac7bd)  ![Gradience@48x48](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/6e36a2f9-6661-47b3-a573-0718cd80469d)  ![Gradience@32x32](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/9549aef6-f015-4814-ae73-6e4c83ddc309)  ![Gradience@24x24](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/b386a36f-e32a-4b77-8112-27ae2699023e)  ![Gradience@16x16](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/d764b058-033d-410f-821e-8589b62d9b10)  


![gradience](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/140589474/d5ef33f7-2f84-418b-9713-719ccb4e720a)
