### PR TITLE
Add more symlinks for Legacy Launcher

### DIFF
--- a/Papirus/16x16/apps/legacylauncher.svg
+++ b/Papirus/16x16/apps/legacylauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/16x16/apps/ru.turikhay.tlauncher.svg
+++ b/Papirus/16x16/apps/ru.turikhay.tlauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/22x22/apps/legacylauncher.svg
+++ b/Papirus/22x22/apps/legacylauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/22x22/apps/ru.turikhay.tlauncher.svg
+++ b/Papirus/22x22/apps/ru.turikhay.tlauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/24x24/apps/legacylauncher.svg
+++ b/Papirus/24x24/apps/legacylauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/24x24/apps/ru.turikhay.tlauncher.svg
+++ b/Papirus/24x24/apps/ru.turikhay.tlauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/32x32/apps/legacylauncher.svg
+++ b/Papirus/32x32/apps/legacylauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/32x32/apps/ru.turikhay.tlauncher.svg
+++ b/Papirus/32x32/apps/ru.turikhay.tlauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/48x48/apps/legacylauncher.svg
+++ b/Papirus/48x48/apps/legacylauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/48x48/apps/ru.turikhay.tlauncher.svg
+++ b/Papirus/48x48/apps/ru.turikhay.tlauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/64x64/apps/legacylauncher.svg
+++ b/Papirus/64x64/apps/legacylauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg

--- a/Papirus/64x64/apps/ru.turikhay.tlauncher.svg
+++ b/Papirus/64x64/apps/ru.turikhay.tlauncher.svg
@@ -1,0 +1,1 @@
+minecraft.svg


### PR DESCRIPTION
Legacy Launcher (previously, TLauncher) is a Minecraft launcher.

The official website ([https://llaun.ch/en](https://llaun.ch/en)) provides links to:
- a Flatpak package (icon is `ch.tlaun.TL`);
- a Debian package (icon is `legacylauncher`);
- a plain Java Archive (icon is `ru.turikhay.tlauncher`).

The symlink for icon name `ch.tlaun.TL` has already been added with PR #3500.
With this PR, I'm adding symlinks for the other two icon names.
