### PR TITLE
Added shadow to Libation icons

### DIFF
--- a/Papirus/22x22/apps/libation.svg
+++ b/Papirus/22x22/apps/libation.svg
@@ -1,7 +1,9 @@
 <svg width="22" height="22" version="1.1" xmlns="http://www.w3.org/2000/svg">
- <circle transform="translate(-1,-1)" cx="12" cy="12.5" r="10" style="opacity:.2"/>
- <circle transform="translate(-1,-1)" cx="12" cy="12" r="10" style="fill:#4f4f4f"/>
- <path transform="translate(-1,-1)" d="M 12,2 A 10,10 0 0 0 2,12 10,10 0 0 0 2.0098,12.293 10,10 0 0 1 12,2.5 10,10 0 0 1 21.99,12.207 10,10 0 0 0 22,12 10,10 0 0 0 12,2 Z" style="fill:#ffffff;opacity:.2"/>
+ <circle cx="11" cy="11.5" r="10" style="opacity:.2"/>
+ <circle cx="11" cy="11" r="10" style="fill:#4f4f4f"/>
+ <path d="M 11,1 A 10,10 0 0 0 1,11 10,10 0 0 0 1.0098,11.293 10,10 0 0 1 11,1.5 10,10 0 0 1 20.99,11.207 10,10 0 0 0 21,11 10,10 0 0 0 11,1 Z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m8.5 18h5m-2.5 0v-5m-3.5-4.5c0-2 1-3.5 1-3.5h5s1 1.5 1 3.5c0 4.498154-3.003288 4.5-3.5 4.5s-3.5-0.0035-3.5-4.5z" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke:#030303"/>
+ <path d="m9 8.5h4c0 3-1.501157 3-2 3s-2 0-2-3z" style="opacity:.2"/>
  <path d="m8.5 17.5h5m-2.5 0v-5m-3.5-4.5c0-2 1-3.5 1-3.5h5s1 1.5 1 3.5c0 4.498154-3.003288 4.5-3.5 4.5s-3.5-0.0035-3.5-4.5z" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke:#e4e4e4"/>
  <path d="m9 8h4c0 3-1.501157 3-2 3s-2 0-2-3z" style="fill:#e4e4e4"/>
 </svg>

--- a/Papirus/22x22/apps/libation.svg
+++ b/Papirus/22x22/apps/libation.svg
@@ -1,7 +1,7 @@
 <svg width="22" height="22" version="1.1" xmlns="http://www.w3.org/2000/svg">
  <circle cx="11" cy="11.5" r="10" style="opacity:.2"/>
  <circle cx="11" cy="11" r="10" style="fill:#4f4f4f"/>
- <path d="M 11,1 A 10,10 0 0 0 1,11 10,10 0 0 0 1.0098,11.293 10,10 0 0 1 11,1.5 10,10 0 0 1 20.99,11.207 10,10 0 0 0 21,11 10,10 0 0 0 11,1 Z" style="fill:#ffffff;opacity:.2"/>
+ <path d="M 11,1 A 10,10 0 0 0 1,11 10,10 0 0 0 1.0098,11.293 10,10 0 0 1 11,1.5 10,10 0 0 1 20.99,11.207 10,10 0 0 0 21,11 10,10 0 0 0 11,1 Z" style="fill:#ffffff;opacity:.1"/>
  <path d="m8.5 18h5m-2.5 0v-5m-3.5-4.5c0-2 1-3.5 1-3.5h5s1 1.5 1 3.5c0 4.498154-3.003288 4.5-3.5 4.5s-3.5-0.0035-3.5-4.5z" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke:#030303"/>
  <path d="m9 8.5h4c0 3-1.501157 3-2 3s-2 0-2-3z" style="opacity:.2"/>
  <path d="m8.5 17.5h5m-2.5 0v-5m-3.5-4.5c0-2 1-3.5 1-3.5h5s1 1.5 1 3.5c0 4.498154-3.003288 4.5-3.5 4.5s-3.5-0.0035-3.5-4.5z" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke:#e4e4e4"/>

--- a/Papirus/24x24/apps/libation.svg
+++ b/Papirus/24x24/apps/libation.svg
@@ -2,8 +2,12 @@
  <g>
   <circle cx="12" cy="12.5" r="10" style="opacity:.2"/>
   <circle cx="12" cy="12" r="10" style="fill:#4f4f4f"/>
-  <path d="m12 2a10 10 0 0 0-10 10 10 10 0 0 0 0.0098 0.293 10 10 0 0 1 9.9902-9.793 10 10 0 0 1 9.99 9.707 10 10 0 0 0 0.01-0.207 10 10 0 0 0-10-10z" style="fill:#ffffff;opacity:.2"/>
+  <path d="M 12,2 A 10,10 0 0 0 2,12 10,10 0 0 0 2.0098,12.293 10,10 0 0 1 12,2.5 10,10 0 0 1 21.99,12.207 10,10 0 0 0 22,12 10,10 0 0 0 12,2 Z" style="fill:#ffffff;opacity:.2"/>
  </g>
+ <path d="m9.5 6h5s1 1.5 1 3.5c0 4.5-3 4.5-3.5 4.5s-3.5 0-3.5-4.5c0-1.9952054 1-3.5 1-3.5z" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke:#000000"/>
+ <path d="m9.5 19h5" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke:#000000"/>
+ <path d="m12 19v-5" style="fill:none;opacity:.2;stroke:#000000"/>
+ <path d="m10 9.5h4c0 3-1.499732 3-2 3s-2 0.0055-2-3z" style="opacity:.2"/>
  <path d="m9.5 5.5h5s1 1.5 1 3.5c0 4.5-3 4.5-3.5 4.5s-3.5 0-3.5-4.5c0-1.9952054 1-3.5 1-3.5z" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke:#e4e4e4"/>
  <path d="m9.5 18.5h5" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke:#e4e4e4"/>
  <path d="m12 18.5v-5" style="fill:none;stroke:#e4e4e4"/>

--- a/Papirus/24x24/apps/libation.svg
+++ b/Papirus/24x24/apps/libation.svg
@@ -2,7 +2,7 @@
  <g>
   <circle cx="12" cy="12.5" r="10" style="opacity:.2"/>
   <circle cx="12" cy="12" r="10" style="fill:#4f4f4f"/>
-  <path d="M 12,2 A 10,10 0 0 0 2,12 10,10 0 0 0 2.0098,12.293 10,10 0 0 1 12,2.5 10,10 0 0 1 21.99,12.207 10,10 0 0 0 22,12 10,10 0 0 0 12,2 Z" style="fill:#ffffff;opacity:.2"/>
+  <path d="M 12,2 A 10,10 0 0 0 2,12 10,10 0 0 0 2.0098,12.293 10,10 0 0 1 12,2.5 10,10 0 0 1 21.99,12.207 10,10 0 0 0 22,12 10,10 0 0 0 12,2 Z" style="fill:#ffffff;opacity:.1"/>
  </g>
  <path d="m9.5 6h5s1 1.5 1 3.5c0 4.5-3 4.5-3.5 4.5s-3.5 0-3.5-4.5c0-1.9952054 1-3.5 1-3.5z" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke:#000000"/>
  <path d="m9.5 19h5" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke:#000000"/>

--- a/Papirus/32x32/apps/libation.svg
+++ b/Papirus/32x32/apps/libation.svg
@@ -1,7 +1,9 @@
 <svg width="32" height="32" version="1.1" xmlns="http://www.w3.org/2000/svg">
  <circle cx="16" cy="17" r="14" style="opacity:.2"/>
  <circle cx="16" cy="16" r="14" style="fill:#4f4f4f"/>
- <path d="M 16 2 A 14 14 0 0 0 2 16 A 14 14 0 0 0 2.0215 16.586 A 14 14 0 0 1 16 3 A 14 14 0 0 1 29.979 16.414 A 14 14 0 0 0 30 16 A 14 14 0 0 0 16 2 z" style="fill:#ffffff;opacity:.2"/>
+ <path d="M 16,2 A 14,14 0 0 0 2,16 14,14 0 0 0 2.0215,16.586 14,14 0 0 1 16,3 14,14 0 0 1 29.979,16.414 14,14 0 0 0 30,16 14,14 0 0 0 16,2 Z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m13 26h6m-3 0v-7m-5-6c0-2.49732 1.375-5 1.375-5h7.25s1.375 2.50268 1.375 5c0 6-3.499133 6-5 6s-5 0-5-6z" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-width:2;stroke:#000000"/>
+ <path d="m13 13c0 4 1.503464 4 3 4s3 0 3-4z" style="opacity:.2"/>
  <path d="m13 25h6m-3 0v-7m-5-6c0-2.4973202 1.375-5 1.375-5h7.25s1.375 2.5026799 1.375 5c0 6-3.499133 6-5 6s-5 0-5-6z" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:2;stroke:#e4e4e4"/>
  <path d="m13 12c0 4 1.503464 4 3 4s3 0 3-4z" style="fill:#e4e4e4"/>
 </svg>

--- a/Papirus/32x32/apps/libation.svg
+++ b/Papirus/32x32/apps/libation.svg
@@ -1,7 +1,7 @@
 <svg width="32" height="32" version="1.1" xmlns="http://www.w3.org/2000/svg">
  <circle cx="16" cy="17" r="14" style="opacity:.2"/>
  <circle cx="16" cy="16" r="14" style="fill:#4f4f4f"/>
- <path d="M 16,2 A 14,14 0 0 0 2,16 14,14 0 0 0 2.0215,16.586 14,14 0 0 1 16,3 14,14 0 0 1 29.979,16.414 14,14 0 0 0 30,16 14,14 0 0 0 16,2 Z" style="fill:#ffffff;opacity:.2"/>
+ <path d="M 16,2 A 14,14 0 0 0 2,16 14,14 0 0 0 2.0215,16.586 14,14 0 0 1 16,3 14,14 0 0 1 29.979,16.414 14,14 0 0 0 30,16 14,14 0 0 0 16,2 Z" style="fill:#ffffff;opacity:.1"/>
  <path d="m13 26h6m-3 0v-7m-5-6c0-2.49732 1.375-5 1.375-5h7.25s1.375 2.50268 1.375 5c0 6-3.499133 6-5 6s-5 0-5-6z" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-width:2;stroke:#000000"/>
  <path d="m13 13c0 4 1.503464 4 3 4s3 0 3-4z" style="opacity:.2"/>
  <path d="m13 25h6m-3 0v-7m-5-6c0-2.4973202 1.375-5 1.375-5h7.25s1.375 2.5026799 1.375 5c0 6-3.499133 6-5 6s-5 0-5-6z" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:2;stroke:#e4e4e4"/>

--- a/Papirus/48x48/apps/libation.svg
+++ b/Papirus/48x48/apps/libation.svg
@@ -1,7 +1,9 @@
 <svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg">
  <circle cx="24" cy="25" r="20" style="opacity:.2"/>
  <circle cx="24" cy="24" r="20" style="fill:#4f4f4f"/>
- <path d="M 24 4 A 20 20 0 0 0 4 24 A 20 20 0 0 0 4.0215 24.582 A 20 20 0 0 1 24 5 A 20 20 0 0 1 43.979 24.418 A 20 20 0 0 0 44 24 A 20 20 0 0 0 24 4 z" style="fill:#ffffff;opacity:.2"/>
+ <path d="M 24,4 A 20,20 0 0 0 4,24 20,20 0 0 0 4.0215,24.582 20,20 0 0 1 24,5 20,20 0 0 1 43.979,24.418 20,20 0 0 0 44,24 20,20 0 0 0 24,4 Z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m17 19c0-4 2-7 2-7h10s2 3 2 7c0 9-7 9-7 9s-7 0-7-9zm7 9v9.942133m-5 0.057867h10" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-width:2;stroke:#000000"/>
+ <path d="m19 19h10c0 7-5 7-5 7s-5 0-5-7z" style="opacity:.2"/>
  <path d="m17 18c0-4 2-7 2-7h10s2 3 2 7c0 9-7 9-7 9s-7 0-7-9zm7 9v9.942133m-5 0.057867h10" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:2;stroke:#e4e4e4"/>
  <path d="m19 18h10c0 7-5 7-5 7s-5 0-5-7z" style="fill:#e4e4e4"/>
 </svg>

--- a/Papirus/48x48/apps/libation.svg
+++ b/Papirus/48x48/apps/libation.svg
@@ -1,7 +1,7 @@
 <svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg">
  <circle cx="24" cy="25" r="20" style="opacity:.2"/>
  <circle cx="24" cy="24" r="20" style="fill:#4f4f4f"/>
- <path d="M 24,4 A 20,20 0 0 0 4,24 20,20 0 0 0 4.0215,24.582 20,20 0 0 1 24,5 20,20 0 0 1 43.979,24.418 20,20 0 0 0 44,24 20,20 0 0 0 24,4 Z" style="fill:#ffffff;opacity:.2"/>
+ <path d="M 24,4 A 20,20 0 0 0 4,24 20,20 0 0 0 4.0215,24.582 20,20 0 0 1 24,5 20,20 0 0 1 43.979,24.418 20,20 0 0 0 44,24 20,20 0 0 0 24,4 Z" style="fill:#ffffff;opacity:.1"/>
  <path d="m17 19c0-4 2-7 2-7h10s2 3 2 7c0 9-7 9-7 9s-7 0-7-9zm7 9v9.942133m-5 0.057867h10" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-width:2;stroke:#000000"/>
  <path d="m19 19h10c0 7-5 7-5 7s-5 0-5-7z" style="opacity:.2"/>
  <path d="m17 18c0-4 2-7 2-7h10s2 3 2 7c0 9-7 9-7 9s-7 0-7-9zm7 9v9.942133m-5 0.057867h10" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:2;stroke:#e4e4e4"/>

--- a/Papirus/64x64/apps/libation.svg
+++ b/Papirus/64x64/apps/libation.svg
@@ -1,7 +1,7 @@
 <svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
  <circle cx="32" cy="33" r="28" style="opacity:.2"/>
  <circle cx="32" cy="32" r="28" style="fill:#4f4f4f"/>
- <path d="M 32,4 A 28,28 0 0 0 4,32 28,28 0 0 0 4.0215,32.586 28,28 0 0 1 32,5 28,28 0 0 1 59.979,32.414 28,28 0 0 0 60,32 28,28 0 0 0 32,4 Z" style="fill:#ffffff;opacity:.2"/>
+ <path d="M 32,4 A 28,28 0 0 0 4,32 28,28 0 0 0 4.0215,32.586 28,28 0 0 1 32,5 28,28 0 0 1 59.979,32.414 28,28 0 0 0 60,32 28,28 0 0 0 32,4 Z" style="fill:#ffffff;opacity:.1"/>
  <path d="m25 51.5h13.5m-17-26.5c0-6 3-10.5 3-10.5h15s3.044 4.5 3.044 10.5c0 12.503304-8.544 12.527008-10.544 12.5s-10.5 0.004063-10.5-12.5z" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-width:3;stroke:#000000"/>
  <path d="m25 50.5h13.5m-17-26.5c0-6 3-10.5 3-10.5h15s3.044 4.5 3.044 10.5c0 12.503304-8.544 12.527008-10.544 12.5s-10.5 0.004063-10.5-12.5z" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:3;stroke:#e4e4e4"/>
  <path d="m32 50v-13" style="fill:none;stroke-width:4;stroke:#e4e4e4"/>

--- a/Papirus/64x64/apps/libation.svg
+++ b/Papirus/64x64/apps/libation.svg
@@ -1,8 +1,10 @@
 <svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
  <circle cx="32" cy="33" r="28" style="opacity:.2"/>
  <circle cx="32" cy="32" r="28" style="fill:#4f4f4f"/>
- <path d="M 32 4 A 28 28 0 0 0 4 32 A 28 28 0 0 0 4.0215 32.586 A 28 28 0 0 1 32 5 A 28 28 0 0 1 59.979 32.414 A 28 28 0 0 0 60 32 A 28 28 0 0 0 32 4 z" style="fill:#ffffff;opacity:.2"/>
+ <path d="M 32,4 A 28,28 0 0 0 4,32 28,28 0 0 0 4.0215,32.586 28,28 0 0 1 32,5 28,28 0 0 1 59.979,32.414 28,28 0 0 0 60,32 28,28 0 0 0 32,4 Z" style="fill:#ffffff;opacity:.2"/>
+ <path d="m25 51.5h13.5m-17-26.5c0-6 3-10.5 3-10.5h15s3.044 4.5 3.044 10.5c0 12.503304-8.544 12.527008-10.544 12.5s-10.5 0.004063-10.5-12.5z" style="fill:none;opacity:.2;stroke-linecap:round;stroke-linejoin:round;stroke-width:3;stroke:#000000"/>
  <path d="m25 50.5h13.5m-17-26.5c0-6 3-10.5 3-10.5h15s3.044 4.5 3.044 10.5c0 12.503304-8.544 12.527008-10.544 12.5s-10.5 0.004063-10.5-12.5z" style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:3;stroke:#e4e4e4"/>
  <path d="m32 50v-13" style="fill:none;stroke-width:4;stroke:#e4e4e4"/>
+ <path d="m25 25h14c0 9-5 9-7 9s-7 0-7-9z" style="opacity:.2"/>
  <path d="m25 24h14c0 9-5 9-7 9s-7 0-7-9z" style="fill:#e4e4e4"/>
 </svg>


### PR DESCRIPTION
I've just noticed that I didn't add any shadow for the white glass in any of the Libation icons (#3565)... @SmartFinn  did you miss it too or you think it's better this way? I mean, it's a quick fix anyway.