### PR TITLE
Add aliases for new tray icons in Plasma 6

### DIFF
--- a/Papirus/22x22/panel/network-bluetooth-activated.svg
+++ b/Papirus/22x22/panel/network-bluetooth-activated.svg
@@ -1,0 +1,1 @@
+bluetooth-paired.svg

--- a/Papirus/22x22/panel/network-bluetooth-inactive.svg
+++ b/Papirus/22x22/panel/network-bluetooth-inactive.svg
@@ -1,0 +1,1 @@
+bluetooth-disabled.svg

--- a/Papirus/22x22/panel/network-bluetooth.svg
+++ b/Papirus/22x22/panel/network-bluetooth.svg
@@ -1,0 +1,1 @@
+bluetooth-active.svg

--- a/Papirus/22x22/panel/network-mobile-0-locked.svg
+++ b/Papirus/22x22/panel/network-mobile-0-locked.svg
@@ -1,0 +1,1 @@
+network-cellular-secure-signal-none.svg

--- a/Papirus/22x22/panel/network-mobile-0.svg
+++ b/Papirus/22x22/panel/network-mobile-0.svg
@@ -1,0 +1,1 @@
+network-cellular-signal-none.svg

--- a/Papirus/22x22/panel/network-mobile-100-locked.svg
+++ b/Papirus/22x22/panel/network-mobile-100-locked.svg
@@ -1,0 +1,1 @@
+network-cellular-secure-signal-excellent.svg

--- a/Papirus/22x22/panel/network-mobile-100.svg
+++ b/Papirus/22x22/panel/network-mobile-100.svg
@@ -1,0 +1,1 @@
+network-cellular-signal-excellent.svg

--- a/Papirus/22x22/panel/network-mobile-20-locked.svg
+++ b/Papirus/22x22/panel/network-mobile-20-locked.svg
@@ -1,0 +1,1 @@
+network-cellular-secure-signal-none.svg

--- a/Papirus/22x22/panel/network-mobile-20.svg
+++ b/Papirus/22x22/panel/network-mobile-20.svg
@@ -1,0 +1,1 @@
+network-cellular-signal-none.svg

--- a/Papirus/22x22/panel/network-mobile-40-locked.svg
+++ b/Papirus/22x22/panel/network-mobile-40-locked.svg
@@ -1,0 +1,1 @@
+network-cellular-secure-signal-low.svg

--- a/Papirus/22x22/panel/network-mobile-40.svg
+++ b/Papirus/22x22/panel/network-mobile-40.svg
@@ -1,0 +1,1 @@
+network-cellular-signal-low.svg

--- a/Papirus/22x22/panel/network-mobile-60-locked.svg
+++ b/Papirus/22x22/panel/network-mobile-60-locked.svg
@@ -1,0 +1,1 @@
+network-cellular-secure-signal-ok.svg

--- a/Papirus/22x22/panel/network-mobile-60.svg
+++ b/Papirus/22x22/panel/network-mobile-60.svg
@@ -1,0 +1,1 @@
+network-cellular-signal-ok.svg

--- a/Papirus/22x22/panel/network-mobile-80-locked.svg
+++ b/Papirus/22x22/panel/network-mobile-80-locked.svg
@@ -1,0 +1,1 @@
+network-cellular-secure-signal-good.svg

--- a/Papirus/22x22/panel/network-mobile-80.svg
+++ b/Papirus/22x22/panel/network-mobile-80.svg
@@ -1,0 +1,1 @@
+network-cellular-signal-good.svg

--- a/Papirus/22x22/panel/network-wireless-0-locked.svg
+++ b/Papirus/22x22/panel/network-wireless-0-locked.svg
@@ -1,0 +1,1 @@
+network-wireless-secure-signal-none.svg

--- a/Papirus/22x22/panel/network-wireless-0.svg
+++ b/Papirus/22x22/panel/network-wireless-0.svg
@@ -1,0 +1,1 @@
+network-wireless-signal-none.svg

--- a/Papirus/22x22/panel/network-wireless-100-locked.svg
+++ b/Papirus/22x22/panel/network-wireless-100-locked.svg
@@ -1,0 +1,1 @@
+network-wireless-secure-signal-excellent.svg

--- a/Papirus/22x22/panel/network-wireless-100.svg
+++ b/Papirus/22x22/panel/network-wireless-100.svg
@@ -1,0 +1,1 @@
+network-wireless-signal-excellent.svg

--- a/Papirus/22x22/panel/network-wireless-20-locked.svg
+++ b/Papirus/22x22/panel/network-wireless-20-locked.svg
@@ -1,0 +1,1 @@
+network-wireless-secure-signal-none.svg

--- a/Papirus/22x22/panel/network-wireless-20.svg
+++ b/Papirus/22x22/panel/network-wireless-20.svg
@@ -1,0 +1,1 @@
+network-wireless-signal-none.svg

--- a/Papirus/22x22/panel/network-wireless-40-locked.svg
+++ b/Papirus/22x22/panel/network-wireless-40-locked.svg
@@ -1,0 +1,1 @@
+network-wireless-secure-signal-low.svg

--- a/Papirus/22x22/panel/network-wireless-40.svg
+++ b/Papirus/22x22/panel/network-wireless-40.svg
@@ -1,0 +1,1 @@
+network-wireless-signal-low.svg

--- a/Papirus/22x22/panel/network-wireless-60-locked.svg
+++ b/Papirus/22x22/panel/network-wireless-60-locked.svg
@@ -1,0 +1,1 @@
+network-wireless-secure-signal-ok.svg

--- a/Papirus/22x22/panel/network-wireless-60.svg
+++ b/Papirus/22x22/panel/network-wireless-60.svg
@@ -1,0 +1,1 @@
+network-wireless-signal-ok.svg

--- a/Papirus/22x22/panel/network-wireless-80-locked.svg
+++ b/Papirus/22x22/panel/network-wireless-80-locked.svg
@@ -1,0 +1,1 @@
+network-wireless-secure-signal-good.svg

--- a/Papirus/22x22/panel/network-wireless-80.svg
+++ b/Papirus/22x22/panel/network-wireless-80.svg
@@ -1,0 +1,1 @@
+network-wireless-signal-good.svg

--- a/Papirus/22x22/panel/network-wireless-available.svg
+++ b/Papirus/22x22/panel/network-wireless-available.svg
@@ -1,0 +1,1 @@
+network-wireless-offline.svg

--- a/Papirus/22x22/panel/network-wireless-bluetooth.svg
+++ b/Papirus/22x22/panel/network-wireless-bluetooth.svg
@@ -1,0 +1,1 @@
+bluetooth-active.svg


### PR DESCRIPTION
Starting in Plasma 6, tray applets will start to use the system icon theme.

This change adds aliases for some of the new icons, using current ones that make sense.