### PR TITLE
Add symlinks for Plasma BatteryMonitor widget

### DIFF
--- a/Papirus-Dark/symbolic/status/battery-profile-performance-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-profile-performance-symbolic.svg
@@ -1,0 +1,1 @@
+power-profile-performance-symbolic.svg

--- a/Papirus-Dark/symbolic/status/battery-profile-powersave-symbolic.svg
+++ b/Papirus-Dark/symbolic/status/battery-profile-powersave-symbolic.svg
@@ -1,0 +1,1 @@
+power-profile-power-saver-symbolic.svg

--- a/Papirus/symbolic/status/battery-profile-performance-symbolic.svg
+++ b/Papirus/symbolic/status/battery-profile-performance-symbolic.svg
@@ -1,0 +1,1 @@
+power-profile-performance-symbolic.svg

--- a/Papirus/symbolic/status/battery-profile-powersave-symbolic.svg
+++ b/Papirus/symbolic/status/battery-profile-powersave-symbolic.svg
@@ -1,0 +1,1 @@
+power-profile-power-saver-symbolic.svg


### PR DESCRIPTION
Related source: https://invent.kde.org/plasma/plasma-workspace/-/blob/Plasma/6.0/applets/batterymonitor/package/contents/ui/PowerProfileItem.qml?ref_type=heads#L147