### PR TITLE
Add password show/hide symlinks for Plasma 6

### DIFF
--- a/Papirus-Dark/16x16/actions/password-show-off.svg
+++ b/Papirus-Dark/16x16/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus-Dark/16x16/actions/hint.svg
+hint.svg

--- a/Papirus-Dark/16x16/actions/password-show-off.svg
+++ b/Papirus-Dark/16x16/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus-Dark/16x16/actions/hint.svg

--- a/Papirus-Dark/16x16/actions/password-show-on.svg
+++ b/Papirus-Dark/16x16/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus-Dark/16x16/actions/visibility.svg

--- a/Papirus-Dark/16x16/actions/password-show-on.svg
+++ b/Papirus-Dark/16x16/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus-Dark/16x16/actions/visibility.svg
+view-hidden.svg

--- a/Papirus-Dark/22x22/actions/password-show-off.svg
+++ b/Papirus-Dark/22x22/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus-Dark/22x22/actions/hint.svg

--- a/Papirus-Dark/22x22/actions/password-show-off.svg
+++ b/Papirus-Dark/22x22/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus-Dark/22x22/actions/hint.svg
+hint.svg

--- a/Papirus-Dark/22x22/actions/password-show-on.svg
+++ b/Papirus-Dark/22x22/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus-Dark/22x22/actions/visibility.svg

--- a/Papirus-Dark/22x22/actions/password-show-on.svg
+++ b/Papirus-Dark/22x22/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus-Dark/22x22/actions/visibility.svg
+view-hidden.svg

--- a/Papirus-Dark/24x24/actions/password-show-off.svg
+++ b/Papirus-Dark/24x24/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus-Dark/24x24/actions/hint.svg

--- a/Papirus-Dark/24x24/actions/password-show-off.svg
+++ b/Papirus-Dark/24x24/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus-Dark/24x24/actions/hint.svg
+hint.svg

--- a/Papirus-Dark/24x24/actions/password-show-on.svg
+++ b/Papirus-Dark/24x24/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus-Dark/24x24/actions/visibility.svg
+view-hidden.svg

--- a/Papirus-Dark/24x24/actions/password-show-on.svg
+++ b/Papirus-Dark/24x24/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus-Dark/24x24/actions/visibility.svg

--- a/Papirus/16x16/actions/password-show-off.svg
+++ b/Papirus/16x16/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus/16x16/actions/hint.svg
+hint.svg

--- a/Papirus/16x16/actions/password-show-off.svg
+++ b/Papirus/16x16/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus/16x16/actions/hint.svg

--- a/Papirus/16x16/actions/password-show-on.svg
+++ b/Papirus/16x16/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus/16x16/actions/visibility.svg

--- a/Papirus/16x16/actions/password-show-on.svg
+++ b/Papirus/16x16/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus/16x16/actions/visibility.svg
+view-hidden.svg

--- a/Papirus/22x22/actions/password-show-off.svg
+++ b/Papirus/22x22/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus/22x22/actions/hint.svg

--- a/Papirus/22x22/actions/password-show-off.svg
+++ b/Papirus/22x22/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus/22x22/actions/hint.svg
+hint.svg

--- a/Papirus/22x22/actions/password-show-on.svg
+++ b/Papirus/22x22/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus/22x22/actions/visibility.svg
+view-hidden.svg

--- a/Papirus/22x22/actions/password-show-on.svg
+++ b/Papirus/22x22/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus/22x22/actions/visibility.svg

--- a/Papirus/24x24/actions/password-show-off.svg
+++ b/Papirus/24x24/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus/24x24/actions/hint.svg

--- a/Papirus/24x24/actions/password-show-off.svg
+++ b/Papirus/24x24/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus/24x24/actions/hint.svg
+hint.svg

--- a/Papirus/24x24/actions/password-show-on.svg
+++ b/Papirus/24x24/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/Papirus/24x24/actions/visibility.svg
+view-hidden.svg

--- a/Papirus/24x24/actions/password-show-on.svg
+++ b/Papirus/24x24/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/Papirus/24x24/actions/visibility.svg

--- a/ePapirus-Dark/16x16/actions/password-show-off.svg
+++ b/ePapirus-Dark/16x16/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus-Dark/16x16/actions/hint.svg
+hint.svg

--- a/ePapirus-Dark/16x16/actions/password-show-off.svg
+++ b/ePapirus-Dark/16x16/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus-Dark/16x16/actions/hint.svg

--- a/ePapirus-Dark/16x16/actions/password-show-on.svg
+++ b/ePapirus-Dark/16x16/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus-Dark/16x16/actions/visibility.svg

--- a/ePapirus-Dark/16x16/actions/password-show-on.svg
+++ b/ePapirus-Dark/16x16/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus-Dark/16x16/actions/visibility.svg
+view-hidden.svg

--- a/ePapirus-Dark/22x22/actions/password-show-off.svg
+++ b/ePapirus-Dark/22x22/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus-Dark/22x22/actions/hint.svg

--- a/ePapirus-Dark/22x22/actions/password-show-off.svg
+++ b/ePapirus-Dark/22x22/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus-Dark/22x22/actions/hint.svg
+hint.svg

--- a/ePapirus-Dark/22x22/actions/password-show-on.svg
+++ b/ePapirus-Dark/22x22/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus-Dark/22x22/actions/visibility.svg
+view-hidden.svg

--- a/ePapirus-Dark/22x22/actions/password-show-on.svg
+++ b/ePapirus-Dark/22x22/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus-Dark/22x22/actions/visibility.svg

--- a/ePapirus-Dark/24x24/actions/password-show-off.svg
+++ b/ePapirus-Dark/24x24/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus-Dark/24x24/actions/hint.svg
+hint.svg

--- a/ePapirus-Dark/24x24/actions/password-show-off.svg
+++ b/ePapirus-Dark/24x24/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus-Dark/24x24/actions/hint.svg

--- a/ePapirus-Dark/24x24/actions/password-show-on.svg
+++ b/ePapirus-Dark/24x24/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus-Dark/24x24/actions/visibility.svg

--- a/ePapirus-Dark/24x24/actions/password-show-on.svg
+++ b/ePapirus-Dark/24x24/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus-Dark/24x24/actions/visibility.svg
+view-hidden.svg

--- a/ePapirus/16x16/actions/password-show-off.svg
+++ b/ePapirus/16x16/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus/16x16/actions/hint.svg

--- a/ePapirus/16x16/actions/password-show-off.svg
+++ b/ePapirus/16x16/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus/16x16/actions/hint.svg
+hint.svg

--- a/ePapirus/16x16/actions/password-show-on.svg
+++ b/ePapirus/16x16/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus/16x16/actions/visibility.svg

--- a/ePapirus/16x16/actions/password-show-on.svg
+++ b/ePapirus/16x16/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus/16x16/actions/visibility.svg
+view-hidden.svg

--- a/ePapirus/22x22/actions/password-show-off.svg
+++ b/ePapirus/22x22/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus/22x22/actions/hint.svg

--- a/ePapirus/22x22/actions/password-show-off.svg
+++ b/ePapirus/22x22/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus/22x22/actions/hint.svg
+hint.svg

--- a/ePapirus/22x22/actions/password-show-on.svg
+++ b/ePapirus/22x22/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus/22x22/actions/visibility.svg
+view-hidden.svg

--- a/ePapirus/22x22/actions/password-show-on.svg
+++ b/ePapirus/22x22/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus/22x22/actions/visibility.svg

--- a/ePapirus/24x24/actions/password-show-off.svg
+++ b/ePapirus/24x24/actions/password-show-off.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus/24x24/actions/hint.svg
+hint.svg

--- a/ePapirus/24x24/actions/password-show-off.svg
+++ b/ePapirus/24x24/actions/password-show-off.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus/24x24/actions/hint.svg

--- a/ePapirus/24x24/actions/password-show-on.svg
+++ b/ePapirus/24x24/actions/password-show-on.svg
@@ -1,1 +1,1 @@
-/home/lark/git/papirus-icon-theme/ePapirus/24x24/actions/visibility.svg
+view-hidden.svg

--- a/ePapirus/24x24/actions/password-show-on.svg
+++ b/ePapirus/24x24/actions/password-show-on.svg
@@ -1,0 +1,1 @@
+/home/lark/git/papirus-icon-theme/ePapirus/24x24/actions/visibility.svg


### PR DESCRIPTION
Plasma 6 relies on icons named `password-show-off` and `password-show-on` for the password visibility button. This commit adds symlinks for each that point to `hint.svg` and `visibility.svg` respectively.

Fixes #3671.

## Demonstration (kscreenlocker)

### Before:

#### password hidden
![image](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/108753551/bed62d8e-76c6-4f60-bb04-e5355b3fbe75)

#### password shown

![image](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/108753551/61122582-836f-4aaa-ace0-23369dbf737e)


### After:

#### password hidden

![image](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/108753551/47210ab8-7725-4d37-a967-d76e3641500d)

#### password shown

![image](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/108753551/ee673306-a8a5-4623-b79f-3dc3dcbd42c1)
