### PR TITLE
Fix weird inconsistency between GTK/KDE/BSD installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ wget -qO- https://git.io/papirus-icon-theme-install | sh
 #### HOME directory for GTK
 
 ```
-wget -qO- https://git.io/papirus-icon-theme-install | DESTDIR="$HOME/.icons" sh
+wget -qO- https://git.io/papirus-icon-theme-install | env DESTDIR="$HOME/.icons" sh
 ```
 
 #### HOME directory for KDE
 
 ```
-wget -qO- https://git.io/papirus-icon-theme-install | DESTDIR="$HOME/.local/share/icons" sh
+wget -qO- https://git.io/papirus-icon-theme-install | env DESTDIR="$HOME/.local/share/icons" sh
 ```
 
 #### \*BSD systems


### PR DESCRIPTION
Currently only the BSD installation method is prefixed with "env", however the other installation methods could also be prefixed the same way for consistency.