### PR TITLE
Add symlinks for Firefox Dev Edition from Mozilla's PPA

### DIFF
--- a/Papirus/16x16/apps/firefox-devedition.svg
+++ b/Papirus/16x16/apps/firefox-devedition.svg
@@ -1,0 +1,1 @@
+firefox-developer-edition.svg

--- a/Papirus/22x22/apps/firefox-devedition.svg
+++ b/Papirus/22x22/apps/firefox-devedition.svg
@@ -1,0 +1,1 @@
+firefox-developer-edition.svg

--- a/Papirus/24x24/apps/firefox-devedition.svg
+++ b/Papirus/24x24/apps/firefox-devedition.svg
@@ -1,0 +1,1 @@
+firefox-developer-edition.svg

--- a/Papirus/32x32/apps/firefox-devedition.svg
+++ b/Papirus/32x32/apps/firefox-devedition.svg
@@ -1,0 +1,1 @@
+firefox-developer-edition.svg

--- a/Papirus/48x48/apps/firefox-devedition.svg
+++ b/Papirus/48x48/apps/firefox-devedition.svg
@@ -1,0 +1,1 @@
+firefox-developer-edition.svg

--- a/Papirus/64x64/apps/firefox-devedition.svg
+++ b/Papirus/64x64/apps/firefox-devedition.svg
@@ -1,0 +1,1 @@
+firefox-developer-edition.svg


### PR DESCRIPTION
The `.desktop` file uses the ID `firefox-devedition`. Currently, Plasma picks up the default orange Firefox icon from the Papirus theme, even though if go to customise the icon, it has original blue one preselected in the picker.

![ffde-wrong-or8](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/assets/28617290/41cd53d3-ad1f-447f-8584-13d99ce27acd)

---

https://ftp.mozilla.org/pub/devedition/releases/