### PR TITLE
nheko: Update appId symlinks for v0.12.0

### DIFF
--- a/Papirus/16x16/apps/im.nheko.Nheko.svg
+++ b/Papirus/16x16/apps/im.nheko.Nheko.svg
@@ -1,0 +1,1 @@
+nheko.svg

--- a/Papirus/22x22/apps/im.nheko.Nheko.svg
+++ b/Papirus/22x22/apps/im.nheko.Nheko.svg
@@ -1,0 +1,1 @@
+nheko.svg

--- a/Papirus/24x24/apps/im.nheko.Nheko.svg
+++ b/Papirus/24x24/apps/im.nheko.Nheko.svg
@@ -1,0 +1,1 @@
+nheko.svg

--- a/Papirus/32x32/apps/im.nheko.Nheko.svg
+++ b/Papirus/32x32/apps/im.nheko.Nheko.svg
@@ -1,0 +1,1 @@
+nheko.svg

--- a/Papirus/48x48/apps/im.nheko.Nheko.svg
+++ b/Papirus/48x48/apps/im.nheko.Nheko.svg
@@ -1,0 +1,1 @@
+nheko.svg

--- a/Papirus/64x64/apps/im.nheko.Nheko.svg
+++ b/Papirus/64x64/apps/im.nheko.Nheko.svg
@@ -1,0 +1,1 @@
+nheko.svg


### PR DESCRIPTION
nheko 0.12.0 changed the Flatpak ID to `im.nheko.Nheko`, so add compat symlinks accordingly.