### PR TITLE
Add symlinks for visualboyadvance-m

### DIFF
--- a/Papirus/16x16/apps/visualboyadvance-m.svg
+++ b/Papirus/16x16/apps/visualboyadvance-m.svg
@@ -1,0 +1,1 @@
+vbam.svg

--- a/Papirus/22x22/apps/visualboyadvance-m.svg
+++ b/Papirus/22x22/apps/visualboyadvance-m.svg
@@ -1,0 +1,1 @@
+vbam.svg

--- a/Papirus/24x24/apps/visualboyadvance-m.svg
+++ b/Papirus/24x24/apps/visualboyadvance-m.svg
@@ -1,0 +1,1 @@
+vbam.svg

--- a/Papirus/32x32/apps/visualboyadvance-m.svg
+++ b/Papirus/32x32/apps/visualboyadvance-m.svg
@@ -1,0 +1,1 @@
+vbam.svg

--- a/Papirus/48x48/apps/visualboyadvance-m.svg
+++ b/Papirus/48x48/apps/visualboyadvance-m.svg
@@ -1,0 +1,1 @@
+vbam.svg

--- a/Papirus/64x64/apps/visualboyadvance-m.svg
+++ b/Papirus/64x64/apps/visualboyadvance-m.svg
@@ -1,0 +1,1 @@
+vbam.svg


### PR DESCRIPTION
visualboyadvance-m (formerly vba-m) development was picked up by new team several years ago. [The desktop](https://github.com/visualboyadvance-m/visualboyadvance-m/blob/master/src/wx/visualboyadvance-m.desktop) file for visualboyadvance-m uses `visualboyadvance-m`in Icon key. Create symlink from `vbam` to `visualboyadvance-m`