### PR TITLE
add generic printer icon

### DIFF
--- a/Papirus/16x16/apps/printer.svg
+++ b/Papirus/16x16/apps/printer.svg
@@ -1,0 +1,1 @@
+cups.svg

--- a/Papirus/22x22/apps/printer.svg
+++ b/Papirus/22x22/apps/printer.svg
@@ -1,0 +1,1 @@
+cups.svg

--- a/Papirus/24x24/apps/printer.svg
+++ b/Papirus/24x24/apps/printer.svg
@@ -1,0 +1,1 @@
+cups.svg

--- a/Papirus/32x32/apps/printer.svg
+++ b/Papirus/32x32/apps/printer.svg
@@ -1,0 +1,1 @@
+cups.svg

--- a/Papirus/48x48/apps/printer.svg
+++ b/Papirus/48x48/apps/printer.svg
@@ -1,0 +1,1 @@
+cups.svg

--- a/Papirus/64x64/apps/printer.svg
+++ b/Papirus/64x64/apps/printer.svg
@@ -1,0 +1,1 @@
+cups.svg


### PR DESCRIPTION
in debian the the `system-config-printer.desktop` desktop file specifies `Icon=printer` papirus does provide `printer1` this should provide that missing icon.

there are other missing icons in debian but those are for their own separate pull requests.