### PR TITLE
Create a symlink from Ptyxis to Gnome Console

### DIFF
--- a/Papirus/16x16/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/16x16/apps/org.gnome.Ptyxis.svg
@@ -1,1 +1,1 @@
-org.gnome.Console
+org.gnome.Console.svg

--- a/Papirus/16x16/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/16x16/apps/org.gnome.Ptyxis.svg
@@ -1,0 +1,1 @@
+org.gnome.Console

--- a/Papirus/22x22/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/22x22/apps/org.gnome.Ptyxis.svg
@@ -1,1 +1,1 @@
-org.gnome.Console
+org.gnome.Console.svg

--- a/Papirus/22x22/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/22x22/apps/org.gnome.Ptyxis.svg
@@ -1,0 +1,1 @@
+org.gnome.Console

--- a/Papirus/24x24/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/24x24/apps/org.gnome.Ptyxis.svg
@@ -1,1 +1,1 @@
-org.gnome.Console
+org.gnome.Console.svg

--- a/Papirus/24x24/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/24x24/apps/org.gnome.Ptyxis.svg
@@ -1,0 +1,1 @@
+org.gnome.Console

--- a/Papirus/32x32/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/32x32/apps/org.gnome.Ptyxis.svg
@@ -1,1 +1,1 @@
-org.gnome.Console
+org.gnome.Console.svg

--- a/Papirus/32x32/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/32x32/apps/org.gnome.Ptyxis.svg
@@ -1,0 +1,1 @@
+org.gnome.Console

--- a/Papirus/48x48/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/48x48/apps/org.gnome.Ptyxis.svg
@@ -1,1 +1,1 @@
-org.gnome.Console
+org.gnome.Console.svg

--- a/Papirus/48x48/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/48x48/apps/org.gnome.Ptyxis.svg
@@ -1,0 +1,1 @@
+org.gnome.Console

--- a/Papirus/64x64/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/64x64/apps/org.gnome.Ptyxis.svg
@@ -1,1 +1,1 @@
-org.gnome.Console
+org.gnome.Console.svg

--- a/Papirus/64x64/apps/org.gnome.Ptyxis.svg
+++ b/Papirus/64x64/apps/org.gnome.Ptyxis.svg
@@ -1,0 +1,1 @@
+org.gnome.Console


### PR DESCRIPTION
Creates a symlink from org.gnome.Ptyxis to org.gnome.Console. Their icons are incredibly similar, so might as well!