### PR TITLE
Symlink TETR.IO icon

### DIFF
--- a/Papirus/16x16/apps/TETR.IO.svg
+++ b/Papirus/16x16/apps/TETR.IO.svg
@@ -1,0 +1,1 @@
+tetrio-desktop.svg

--- a/Papirus/22x22/apps/TETR.IO.svg
+++ b/Papirus/22x22/apps/TETR.IO.svg
@@ -1,0 +1,1 @@
+tetrio-desktop.svg

--- a/Papirus/24x24/apps/TETR.IO.svg
+++ b/Papirus/24x24/apps/TETR.IO.svg
@@ -1,0 +1,1 @@
+tetrio-desktop.svg

--- a/Papirus/32x32/apps/TETR.IO.svg
+++ b/Papirus/32x32/apps/TETR.IO.svg
@@ -1,0 +1,1 @@
+tetrio-desktop.svg

--- a/Papirus/48x48/apps/TETR.IO.svg
+++ b/Papirus/48x48/apps/TETR.IO.svg
@@ -1,0 +1,1 @@
+tetrio-desktop.svg

--- a/Papirus/64x64/apps/TETR.IO.svg
+++ b/Papirus/64x64/apps/TETR.IO.svg
@@ -1,0 +1,1 @@
+tetrio-desktop.svg


### PR DESCRIPTION
The icon has no padding and does a background thing that didn't look right with the rest of the icons on my dock.

https://tetr.io/about/desktop
https://txt.osk.sh/branding

![tetrio](https://github.com/user-attachments/assets/cca5e5ab-674b-4b4c-bd6a-34bd1abcfad2)
