### PR TITLE
Add generic display icon

### DIFF
--- a/Papirus/16x16/apps/display.svg
+++ b/Papirus/16x16/apps/display.svg
@@ -1,0 +1,1 @@
+preferences-desktop-display.svg

--- a/Papirus/22x22/apps/display.svg
+++ b/Papirus/22x22/apps/display.svg
@@ -1,0 +1,1 @@
+preferences-desktop-display.svg

--- a/Papirus/24x24/apps/display.svg
+++ b/Papirus/24x24/apps/display.svg
@@ -1,0 +1,1 @@
+preferences-desktop-display.svg

--- a/Papirus/32x32/apps/display.svg
+++ b/Papirus/32x32/apps/display.svg
@@ -1,0 +1,1 @@
+preferences-desktop-display.svg

--- a/Papirus/48x48/apps/display.svg
+++ b/Papirus/48x48/apps/display.svg
@@ -1,0 +1,1 @@
+preferences-desktop-display.svg

--- a/Papirus/64x64/apps/display.svg
+++ b/Papirus/64x64/apps/display.svg
@@ -1,0 +1,1 @@
+preferences-desktop-display.svg


### PR DESCRIPTION
[arandr](https://gitlab.com/arandr/arandr) still uses the legacy 'display' icon name instead of the freedesktop icon names 'system-config-display', 'preferences-desktop-display', a pull request was submitted but it doesn't seem to be any interest from the arandr project to stop using the legacy name.

this takes the less resistance approach and just provides the legacy 'display' icon through a symlink.