### PR TITLE
Symlink gmrun icon

### DIFF
--- a/Papirus/16x16/apps/gmrun.svg
+++ b/Papirus/16x16/apps/gmrun.svg
@@ -1,0 +1,1 @@
+preferences-system-login.svg

--- a/Papirus/22x22/apps/gmrun.svg
+++ b/Papirus/22x22/apps/gmrun.svg
@@ -1,0 +1,1 @@
+preferences-system-login.svg

--- a/Papirus/24x24/apps/gmrun.svg
+++ b/Papirus/24x24/apps/gmrun.svg
@@ -1,0 +1,1 @@
+preferences-system-login.svg

--- a/Papirus/32x32/apps/gmrun.svg
+++ b/Papirus/32x32/apps/gmrun.svg
@@ -1,0 +1,1 @@
+preferences-system-login.svg

--- a/Papirus/48x48/apps/gmrun.svg
+++ b/Papirus/48x48/apps/gmrun.svg
@@ -1,0 +1,1 @@
+preferences-system-login.svg

--- a/Papirus/64x64/apps/gmrun.svg
+++ b/Papirus/64x64/apps/gmrun.svg
@@ -1,0 +1,1 @@
+preferences-system-login.svg


### PR DESCRIPTION
This is my first PR for Papirus.  It adds symlinks for `gmrun`, pointing at `preferences-system-login.svg` which is also used by other launcher-type apps.

Please let me know if I need to correct anything.
Thank you!