### PR TITLE
Add symlinks for PCManFM-Qt and Color-Picker.

### DIFF
--- a/Papirus/16x16/apps/color-picker.svg
+++ b/Papirus/16x16/apps/color-picker.svg
@@ -1,0 +1,1 @@
+gnome-color-chooser.svg

--- a/Papirus/16x16/apps/pcmanfm-qt.svg
+++ b/Papirus/16x16/apps/pcmanfm-qt.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/Papirus/22x22/apps/color-picker.svg
+++ b/Papirus/22x22/apps/color-picker.svg
@@ -1,0 +1,1 @@
+gnome-color-chooser.svg

--- a/Papirus/22x22/apps/pcmanfm-qt.svg
+++ b/Papirus/22x22/apps/pcmanfm-qt.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/Papirus/24x24/apps/color-picker.svg
+++ b/Papirus/24x24/apps/color-picker.svg
@@ -1,0 +1,1 @@
+gnome-color-chooser.svg

--- a/Papirus/24x24/apps/pcmanfm-qt.svg
+++ b/Papirus/24x24/apps/pcmanfm-qt.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/Papirus/32x32/apps/color-picker.svg
+++ b/Papirus/32x32/apps/color-picker.svg
@@ -1,0 +1,1 @@
+gnome-color-chooser.svg

--- a/Papirus/32x32/apps/pcmanfm-qt.svg
+++ b/Papirus/32x32/apps/pcmanfm-qt.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/Papirus/48x48/apps/color-picker.svg
+++ b/Papirus/48x48/apps/color-picker.svg
@@ -1,0 +1,1 @@
+gnome-color-chooser.svg

--- a/Papirus/48x48/apps/pcmanfm-qt.svg
+++ b/Papirus/48x48/apps/pcmanfm-qt.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/Papirus/64x64/apps/color-picker.svg
+++ b/Papirus/64x64/apps/color-picker.svg
@@ -1,0 +1,1 @@
+gnome-color-chooser.svg

--- a/Papirus/64x64/apps/pcmanfm-qt.svg
+++ b/Papirus/64x64/apps/pcmanfm-qt.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg


### PR DESCRIPTION
Symlinks to system-file-manager and gnome-color-chooser respectively.

closes #3881