### PR TITLE
symlink sioyek-icon-linux to sioyek

### DIFF
--- a/Papirus/16x16/apps/sioyek-icon-linux.svg
+++ b/Papirus/16x16/apps/sioyek-icon-linux.svg
@@ -1,0 +1,1 @@
+sioyek.svg

--- a/Papirus/22x22/apps/sioyek-icon-linux.svg
+++ b/Papirus/22x22/apps/sioyek-icon-linux.svg
@@ -1,0 +1,1 @@
+sioyek.svg

--- a/Papirus/24x24/apps/sioyek-icon-linux.svg
+++ b/Papirus/24x24/apps/sioyek-icon-linux.svg
@@ -1,0 +1,1 @@
+sioyek.svg

--- a/Papirus/32x32/apps/sioyek-icon-linux.svg
+++ b/Papirus/32x32/apps/sioyek-icon-linux.svg
@@ -1,0 +1,1 @@
+sioyek.svg

--- a/Papirus/48x48/apps/sioyek-icon-linux.svg
+++ b/Papirus/48x48/apps/sioyek-icon-linux.svg
@@ -1,0 +1,1 @@
+sioyek.svg

--- a/Papirus/64x64/apps/sioyek-icon-linux.svg
+++ b/Papirus/64x64/apps/sioyek-icon-linux.svg
@@ -1,0 +1,1 @@
+sioyek.svg


### PR DESCRIPTION
Due to https://github.com/ahrm/sioyek/blob/460b5e3e4c293594a87e29654ea429275683a72f/resources/sioyek.desktop#L10

I had created the sioyek icon, originally. But it does not seem to work in some systems (waybar's taskbar) due to the `.desktop` needing `sioyek-icon-linux` instead of `sioyek`.

This fixes it.