### PR TITLE
docs: Fix scour dependencies for modern Debian.

### DIFF
--- a/tools/ffsvg.sh
+++ b/tools/ffsvg.sh
@@ -37,7 +37,7 @@ _run_helpers() {
 		You have to install svgo or scour to use this script:
 
 		sudo npm install -g svgo
-		sudo apt-get install python-scour
+		sudo apt-get install scour
 
 		EOF
 

--- a/tools/work/README.md
+++ b/tools/work/README.md
@@ -15,14 +15,17 @@ The scripts in this folder require the following programs:
 - Inkscape
 - scour
 
-For Debian/Ubuntu/Linux Mint users:
+You can use your normal Software Center or App Store program to install these. The Scour package's name can vary a bit because it's a Python script, so if installing the package named "`scour`" doesn't work, you can try [looking for it on repology][repology]. For Debian/Ubuntu/Linux Mint users familiar with the command line:
 
 ```sh
 sudo apt update
 sudo apt install inkscape scour
 ```
 
-If you need a more recent version of scour, please install it with pipx.
+Inkscape is very widely available, and you should have no trouble finding it. If you can't find scour in your app center or graphical package manager, or you just need a more recent version of scour than your distribution has available, please install it by name with [`pipx`][pipx] or `pip`.
+
+[repology]: https://repology.org/project/scour/versions
+[pipx]: https://pipx.pypa.io/latest/installation/
 
 ## Step-by-Step Guide
 

--- a/tools/work/README.md
+++ b/tools/work/README.md
@@ -19,7 +19,7 @@ For Debian/Ubuntu/Linux Mint users:
 
 ```sh
 sudo apt update
-sudo apt install inkscape python3-scour
+sudo apt install inkscape scour
 ```
 
 If you need a more recent version of scour, please install it with pipx.


### PR DESCRIPTION
Debian now put the "scour" binary and their own "dh_scour" build helper in a package named "scour", and package merely the libs in "python3-scour". It's been like that for several stable Debian releases: <http://packages.debian.org/scour>