### PR TITLE
feat: add symlink for beepertexts

### DIFF
--- a/Papirus/16x16/apps/beepertexts.svg
+++ b/Papirus/16x16/apps/beepertexts.svg
@@ -1,0 +1,1 @@
+beeper.svg

--- a/Papirus/22x22/apps/beepertexts.svg
+++ b/Papirus/22x22/apps/beepertexts.svg
@@ -1,0 +1,1 @@
+beeper.svg

--- a/Papirus/24x24/apps/beepertexts.svg
+++ b/Papirus/24x24/apps/beepertexts.svg
@@ -1,0 +1,1 @@
+beeper.svg

--- a/Papirus/32x32/apps/beepertexts.svg
+++ b/Papirus/32x32/apps/beepertexts.svg
@@ -1,0 +1,1 @@
+beeper.svg

--- a/Papirus/48x48/apps/beepertexts.svg
+++ b/Papirus/48x48/apps/beepertexts.svg
@@ -1,0 +1,1 @@
+beeper.svg

--- a/Papirus/64x64/apps/beepertexts.svg
+++ b/Papirus/64x64/apps/beepertexts.svg
@@ -1,0 +1,1 @@
+beeper.svg


### PR DESCRIPTION
As a matter of fact, they use `beepertexts` instead of `beeper` from 4.x, so here's the symlinks.