### PR TITLE
Add symlink for dosbox-staging

### DIFF
--- a/Papirus/16x16/apps/org.dosbox-staging.dosbox-staging.svg
+++ b/Papirus/16x16/apps/org.dosbox-staging.dosbox-staging.svg
@@ -1,0 +1,1 @@
+dosbox-staging.svg

--- a/Papirus/22x22/apps/org.dosbox-staging.dosbox-staging.svg
+++ b/Papirus/22x22/apps/org.dosbox-staging.dosbox-staging.svg
@@ -1,0 +1,1 @@
+dosbox-staging.svg

--- a/Papirus/24x24/apps/org.dosbox-staging.dosbox-staging.svg
+++ b/Papirus/24x24/apps/org.dosbox-staging.dosbox-staging.svg
@@ -1,0 +1,1 @@
+dosbox-staging.svg

--- a/Papirus/32x32/apps/org.dosbox-staging.dosbox-staging.svg
+++ b/Papirus/32x32/apps/org.dosbox-staging.dosbox-staging.svg
@@ -1,0 +1,1 @@
+dosbox-staging.svg

--- a/Papirus/48x48/apps/org.dosbox-staging.dosbox-staging.svg
+++ b/Papirus/48x48/apps/org.dosbox-staging.dosbox-staging.svg
@@ -1,0 +1,1 @@
+dosbox-staging.svg

--- a/Papirus/64x64/apps/org.dosbox-staging.dosbox-staging.svg
+++ b/Papirus/64x64/apps/org.dosbox-staging.dosbox-staging.svg
@@ -1,0 +1,1 @@
+dosbox-staging.svg


### PR DESCRIPTION
Add symlink for org.dosbox-staging.dosbox-staging (used in Fedora)