### PR TITLE
view-appgrid-symbolic 48px/64px #3992

### DIFF
--- a/Papirus/48x48/apps/view-app-grid-symbolic.svg
+++ b/Papirus/48x48/apps/view-app-grid-symbolic.svg
@@ -1,0 +1,14 @@
+<svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#444444; } .ColorScheme-Highlight { color:#4285f4; } .ColorScheme-NeutralText { color:#ff9800; } .ColorScheme-PositiveText { color:#4caf50; } .ColorScheme-NegativeText { color:#f44336; }</style>
+ </defs>
+ <rect x="4" y="4" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="19" y="4" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="34" y="4" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="4" y="19" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="19" y="19" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="34" y="19" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="4" y="34" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="19" y="34" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="34" y="34" width="10" height="10" ry="1.7" style="fill:currentColor" class="ColorScheme-Text"/>
+</svg>

--- a/Papirus/64x64/apps/view-app-grid-symbolic.svg
+++ b/Papirus/64x64/apps/view-app-grid-symbolic.svg
@@ -1,0 +1,14 @@
+<svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#444444; } .ColorScheme-Highlight { color:#4285f4; } .ColorScheme-NeutralText { color:#ff9800; } .ColorScheme-PositiveText { color:#4caf50; } .ColorScheme-NegativeText { color:#f44336; }</style>
+ </defs>
+ <rect x="8" y="8" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="26" y="8" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="44" y="8" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="8" y="26" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="26" y="26" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="44" y="26" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="8" y="44" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="26" y="44" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+ <rect x="44" y="44" width="12" height="12" ry="2" style="fill:currentColor" class="ColorScheme-Text"/>
+</svg>


### PR DESCRIPTION
This Gnome launcher icon for 2x scale. We don't have this huge size for symbolic icons. This is an easy workaround, as an exception. I don't see the point in adding new directories for the sake of a single icon.