### PR TITLE
Add symlink for speedometer-symbolic

### DIFF
--- a/Papirus/16x16/symbolic/actions/speedometer-symbolic.svg
+++ b/Papirus/16x16/symbolic/actions/speedometer-symbolic.svg
@@ -1,0 +1,1 @@
+../../actions/speedometer.svg

--- a/Papirus/22x22/symbolic/actions/speedometer-symbolic.svg
+++ b/Papirus/22x22/symbolic/actions/speedometer-symbolic.svg
@@ -1,0 +1,1 @@
+../../actions/speedometer.svg

--- a/Papirus/24x24/symbolic/actions/speedometer-symbolic.svg
+++ b/Papirus/24x24/symbolic/actions/speedometer-symbolic.svg
@@ -1,0 +1,1 @@
+../../actions/speedometer.svg


### PR DESCRIPTION
Add symlink for speedometer-symbolic that used in KDE Plasma tray.

before:
![before](https://github.com/user-attachments/assets/d56837c9-22e3-46d0-af3b-e39671abdfcd)

after:
![after](https://github.com/user-attachments/assets/2bcc24e1-28c2-4662-b007-13312ebed341)
