### PR TITLE
Add Abaddon stub icon

### DIFF
--- a/Papirus/16x16/apps/abaddon.svg
+++ b/Papirus/16x16/apps/abaddon.svg
@@ -1,0 +1,1 @@
+discord-development.svg

--- a/Papirus/22x22/apps/abaddon.svg
+++ b/Papirus/22x22/apps/abaddon.svg
@@ -1,0 +1,1 @@
+discord-development.svg

--- a/Papirus/24x24/apps/abaddon.svg
+++ b/Papirus/24x24/apps/abaddon.svg
@@ -1,0 +1,1 @@
+discord-development.svg

--- a/Papirus/32x32/apps/abaddon.svg
+++ b/Papirus/32x32/apps/abaddon.svg
@@ -1,0 +1,1 @@
+discord-development.svg

--- a/Papirus/48x48/apps/abaddon.svg
+++ b/Papirus/48x48/apps/abaddon.svg
@@ -1,0 +1,1 @@
+discord-development.svg

--- a/Papirus/64x64/apps/abaddon.svg
+++ b/Papirus/64x64/apps/abaddon.svg
@@ -1,0 +1,1 @@
+discord-development.svg


### PR DESCRIPTION
This is useful because the Abaddon Discord client project by itself does not seem to have an icon yet.