### PR TITLE
Add symlink for Reaper (DAW) flatpak

### DIFF
--- a/Papirus/16x16/apps/fm.reaper.Reaper.svg
+++ b/Papirus/16x16/apps/fm.reaper.Reaper.svg
@@ -1,0 +1,1 @@
+cockos-reaper.svg

--- a/Papirus/22x22/apps/fm.reaper.Reaper.svg
+++ b/Papirus/22x22/apps/fm.reaper.Reaper.svg
@@ -1,0 +1,1 @@
+cockos-reaper.svg

--- a/Papirus/24x24/apps/fm.reaper.Reaper.svg
+++ b/Papirus/24x24/apps/fm.reaper.Reaper.svg
@@ -1,0 +1,1 @@
+cockos-reaper.svg

--- a/Papirus/32x32/apps/fm.reaper.Reaper.svg
+++ b/Papirus/32x32/apps/fm.reaper.Reaper.svg
@@ -1,0 +1,1 @@
+cockos-reaper.svg

--- a/Papirus/48x48/apps/fm.reaper.Reaper.svg
+++ b/Papirus/48x48/apps/fm.reaper.Reaper.svg
@@ -1,0 +1,1 @@
+cockos-reaper.svg

--- a/Papirus/64x64/apps/fm.reaper.Reaper.svg
+++ b/Papirus/64x64/apps/fm.reaper.Reaper.svg
@@ -1,0 +1,1 @@
+cockos-reaper.svg


### PR DESCRIPTION
The current icon for Reaper (developed by Cockos Incorporated) is `cockos-reaper.svg`. This adds a symlink `fm.reaper.Reaper.svg` pointing to `cockos-reaper.svg`.