### PR TITLE
Symlink Overwatch Steam icon

### DIFF
--- a/Papirus/16x16/apps/steam_icon_2357570.svg
+++ b/Papirus/16x16/apps/steam_icon_2357570.svg
@@ -1,0 +1,1 @@
+overwatch.svg

--- a/Papirus/22x22/apps/steam_icon_2357570.svg
+++ b/Papirus/22x22/apps/steam_icon_2357570.svg
@@ -1,0 +1,1 @@
+overwatch.svg

--- a/Papirus/24x24/apps/steam_icon_2357570.svg
+++ b/Papirus/24x24/apps/steam_icon_2357570.svg
@@ -1,0 +1,1 @@
+overwatch.svg

--- a/Papirus/32x32/apps/steam_icon_2357570.svg
+++ b/Papirus/32x32/apps/steam_icon_2357570.svg
@@ -1,0 +1,1 @@
+overwatch.svg

--- a/Papirus/48x48/apps/steam_icon_2357570.svg
+++ b/Papirus/48x48/apps/steam_icon_2357570.svg
@@ -1,0 +1,1 @@
+overwatch.svg

--- a/Papirus/64x64/apps/steam_icon_2357570.svg
+++ b/Papirus/64x64/apps/steam_icon_2357570.svg
@@ -1,0 +1,1 @@
+overwatch.svg


### PR DESCRIPTION
It's much easier to play Overwatch through Steam on Linux now, most users are likely launching it this way.

https://store.steampowered.com/app/2357570/Overwatch_2/
