### PR TITLE
symlink org.jellyfin.JellyfinDesktop

### DIFF
--- a/Papirus/16x16/apps/org.jellyfin.JellyfinDesktop.svg
+++ b/Papirus/16x16/apps/org.jellyfin.JellyfinDesktop.svg
@@ -1,0 +1,1 @@
+jellyfin-desktop.svg

--- a/Papirus/22x22/apps/org.jellyfin.JellyfinDesktop.svg
+++ b/Papirus/22x22/apps/org.jellyfin.JellyfinDesktop.svg
@@ -1,0 +1,1 @@
+jellyfin-desktop.svg

--- a/Papirus/24x24/apps/org.jellyfin.JellyfinDesktop.svg
+++ b/Papirus/24x24/apps/org.jellyfin.JellyfinDesktop.svg
@@ -1,0 +1,1 @@
+jellyfin-desktop.svg

--- a/Papirus/32x32/apps/org.jellyfin.JellyfinDesktop.svg
+++ b/Papirus/32x32/apps/org.jellyfin.JellyfinDesktop.svg
@@ -1,0 +1,1 @@
+jellyfin-desktop.svg

--- a/Papirus/48x48/apps/org.jellyfin.JellyfinDesktop.svg
+++ b/Papirus/48x48/apps/org.jellyfin.JellyfinDesktop.svg
@@ -1,0 +1,1 @@
+jellyfin-desktop.svg

--- a/Papirus/64x64/apps/org.jellyfin.JellyfinDesktop.svg
+++ b/Papirus/64x64/apps/org.jellyfin.JellyfinDesktop.svg
@@ -1,0 +1,1 @@
+jellyfin-desktop.svg


### PR DESCRIPTION
Jellyfin Media Player was renamed to Jellyfin Desktop starting with v2. As part of this change, the application icon name used in the `.desktop` file was updated from `com.github.iwalton3.jellyfin-media-player` to `org.jellyfin.JellyfinDesktop`.

This pull request adds symlinks for `org.jellyfin.JellyfinDesktop.svg`.