### PR TITLE
Symlink 'ru.wohlsoft.TheXTech' to 'thextech'

### DIFF
--- a/Papirus/16x16/apps/ru.wohlsoft.TheXTech.svg
+++ b/Papirus/16x16/apps/ru.wohlsoft.TheXTech.svg
@@ -1,0 +1,1 @@
+thextech.svg

--- a/Papirus/22x22/apps/ru.wohlsoft.TheXTech.svg
+++ b/Papirus/22x22/apps/ru.wohlsoft.TheXTech.svg
@@ -1,0 +1,1 @@
+thextech.svg

--- a/Papirus/24x24/apps/ru.wohlsoft.TheXTech.svg
+++ b/Papirus/24x24/apps/ru.wohlsoft.TheXTech.svg
@@ -1,0 +1,1 @@
+thextech.svg

--- a/Papirus/32x32/apps/ru.wohlsoft.TheXTech.svg
+++ b/Papirus/32x32/apps/ru.wohlsoft.TheXTech.svg
@@ -1,0 +1,1 @@
+thextech.svg

--- a/Papirus/48x48/apps/ru.wohlsoft.TheXTech.svg
+++ b/Papirus/48x48/apps/ru.wohlsoft.TheXTech.svg
@@ -1,0 +1,1 @@
+thextech.svg

--- a/Papirus/64x64/apps/ru.wohlsoft.TheXTech.svg
+++ b/Papirus/64x64/apps/ru.wohlsoft.TheXTech.svg
@@ -1,0 +1,1 @@
+thextech.svg


### PR DESCRIPTION
TheXTech now has its own Flatpak package which goes by `ru.wohlsoft.TheXTech`. This pull request links it to the existing icon used for the deb package (named `thextech`).