### PR TITLE
Add symlink for org.nomacs.ImageLounge

### DIFF
--- a/Papirus/16x16/apps/org.nomacs.ImageLounge.svg
+++ b/Papirus/16x16/apps/org.nomacs.ImageLounge.svg
@@ -1,0 +1,1 @@
+nomacs.svg

--- a/Papirus/22x22/apps/org.nomacs.ImageLounge.svg
+++ b/Papirus/22x22/apps/org.nomacs.ImageLounge.svg
@@ -1,0 +1,1 @@
+nomacs.svg

--- a/Papirus/24x24/apps/org.nomacs.ImageLounge.svg
+++ b/Papirus/24x24/apps/org.nomacs.ImageLounge.svg
@@ -1,0 +1,1 @@
+nomacs.svg

--- a/Papirus/32x32/apps/org.nomacs.ImageLounge.svg
+++ b/Papirus/32x32/apps/org.nomacs.ImageLounge.svg
@@ -1,0 +1,1 @@
+nomacs.svg

--- a/Papirus/48x48/apps/org.nomacs.ImageLounge.svg
+++ b/Papirus/48x48/apps/org.nomacs.ImageLounge.svg
@@ -1,0 +1,1 @@
+nomacs.svg

--- a/Papirus/64x64/apps/org.nomacs.ImageLounge.svg
+++ b/Papirus/64x64/apps/org.nomacs.ImageLounge.svg
@@ -1,0 +1,1 @@
+nomacs.svg


### PR DESCRIPTION
Add symlink org.nomacs.ImageLounge.svg which is used in Fedora (and more)