### PR TITLE
Add symlinks for `ungoogled-chromium-browser`

### DIFF
--- a/Papirus/16x16/apps/ungoogled-chromium-browser.svg
+++ b/Papirus/16x16/apps/ungoogled-chromium-browser.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/22x22/apps/ungoogled-chromium-browser.svg
+++ b/Papirus/22x22/apps/ungoogled-chromium-browser.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/24x24/apps/ungoogled-chromium-browser.svg
+++ b/Papirus/24x24/apps/ungoogled-chromium-browser.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/32x32/apps/ungoogled-chromium-browser.svg
+++ b/Papirus/32x32/apps/ungoogled-chromium-browser.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/48x48/apps/ungoogled-chromium-browser.svg
+++ b/Papirus/48x48/apps/ungoogled-chromium-browser.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Papirus/64x64/apps/ungoogled-chromium-browser.svg
+++ b/Papirus/64x64/apps/ungoogled-chromium-browser.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg


### PR DESCRIPTION
The Gentoo package for ungoogled-chromium recently added separation from the official filenames for Chromium binaries, including icons. This PR adds symlinks from `ungoogled-chromium-browser` to `chromium-browser` to support this change.