### PR TITLE
Add symlink for brave-origin-nightly -> brave-browser-nightly

### DIFF
--- a/Papirus/16x16/apps/brave-origin-nightly.svg
+++ b/Papirus/16x16/apps/brave-origin-nightly.svg
@@ -1,0 +1,1 @@
+brave-browser-nightly.svg

--- a/Papirus/22x22/apps/brave-origin-nightly.svg
+++ b/Papirus/22x22/apps/brave-origin-nightly.svg
@@ -1,0 +1,1 @@
+brave-browser-nightly.svg

--- a/Papirus/24x24/apps/brave-origin-nightly.svg
+++ b/Papirus/24x24/apps/brave-origin-nightly.svg
@@ -1,0 +1,1 @@
+brave-browser-nightly.svg

--- a/Papirus/32x32/apps/brave-origin-nightly.svg
+++ b/Papirus/32x32/apps/brave-origin-nightly.svg
@@ -1,0 +1,1 @@
+brave-browser-nightly.svg

--- a/Papirus/48x48/apps/brave-origin-nightly.svg
+++ b/Papirus/48x48/apps/brave-origin-nightly.svg
@@ -1,0 +1,1 @@
+brave-browser-nightly.svg

--- a/Papirus/64x64/apps/brave-origin-nightly.svg
+++ b/Papirus/64x64/apps/brave-origin-nightly.svg
@@ -1,0 +1,1 @@
+brave-browser-nightly.svg


### PR DESCRIPTION
Add symlink for brave-origin-nightly -> brave-browser-nightly

Description: 
brave-browser-nightly.svg exists in the theme but there's no symlink for brave-origin-nightly, which is the icon name used by the Brave Origin Nightly build. This means the icon doesn't resolve and falls back to the default.

At least this was present on Fedora 44 with my install of nightly. 