### PR TITLE
Add symlinks for `text-x-shellscript`

### DIFF
--- a/Papirus/16x16/mimetypes/text-x-shellscript.svg
+++ b/Papirus/16x16/mimetypes/text-x-shellscript.svg
@@ -1,0 +1,1 @@
+text-x-script.svg

--- a/Papirus/22x22/mimetypes/text-x-shellscript.svg
+++ b/Papirus/22x22/mimetypes/text-x-shellscript.svg
@@ -1,0 +1,1 @@
+text-x-script.svg

--- a/Papirus/24x24/mimetypes/text-x-shellscript.svg
+++ b/Papirus/24x24/mimetypes/text-x-shellscript.svg
@@ -1,0 +1,1 @@
+text-x-script.svg

--- a/Papirus/32x32/mimetypes/text-x-shellscript.svg
+++ b/Papirus/32x32/mimetypes/text-x-shellscript.svg
@@ -1,0 +1,1 @@
+text-x-script.svg

--- a/Papirus/48x48/mimetypes/text-x-shellscript.svg
+++ b/Papirus/48x48/mimetypes/text-x-shellscript.svg
@@ -1,0 +1,1 @@
+text-x-script.svg

--- a/Papirus/64x64/mimetypes/text-x-shellscript.svg
+++ b/Papirus/64x64/mimetypes/text-x-shellscript.svg
@@ -1,0 +1,1 @@
+text-x-script.svg


### PR DESCRIPTION
Following the upstream xdg mime type change: https://gitlab.freedesktop.org/xdg/shared-mime-info/-/work_items/249