### PR TITLE
Add Cider symlink

### DIFF
--- a/Papirus/16x16/apps/Cider.svg
+++ b/Papirus/16x16/apps/Cider.svg
@@ -1,0 +1,1 @@
+cider.svg

--- a/Papirus/22x22/apps/Cider.svg
+++ b/Papirus/22x22/apps/Cider.svg
@@ -1,0 +1,1 @@
+cider.svg

--- a/Papirus/24x24/apps/Cider.svg
+++ b/Papirus/24x24/apps/Cider.svg
@@ -1,0 +1,1 @@
+cider.svg

--- a/Papirus/32x32/apps/Cider.svg
+++ b/Papirus/32x32/apps/Cider.svg
@@ -1,0 +1,1 @@
+cider.svg

--- a/Papirus/48x48/apps/Cider.svg
+++ b/Papirus/48x48/apps/Cider.svg
@@ -1,0 +1,1 @@
+cider.svg

--- a/Papirus/64x64/apps/Cider.svg
+++ b/Papirus/64x64/apps/Cider.svg
@@ -1,0 +1,1 @@
+cider.svg


### PR DESCRIPTION
For some reason when I installed Cider it pointed the icon to 'Cider' rather than 'cider'. Easy fix though. Let me know if I did something wrong.